### PR TITLE
Replace apikey project id and build args with a .testsweet config file [WIP]

### DIFF
--- a/packages/testsweets/bin/testsweets.dart
+++ b/packages/testsweets/bin/testsweets.dart
@@ -16,14 +16,12 @@ Future<void> main(List<String> args) async {
   }
 
   final _buildArgumentsError =
-      '''Expected arguments to have the form: buildAndUpload appType buildMode projectId apiKey
+      '''Expected arguments to have the form: buildAndUpload appType
 
 Where:
   appType can be apk or ipa
-  buildMode can be debug or profile
-  projectId is the id of the Test Sweets project you want to upload this build to
-  apiKey is the API key for the project you want to upload this build to
 
+you need to add .testsweets file at the root of your project containing the folowing parameters
 You can find both the API key and the project id for your project in the project
 settings tab in Test Sweets.
 
@@ -43,10 +41,8 @@ For example:
 
   final command = args[0];
   final appType = args[1];
-  final buildMode = '';
 
-  if (!['buildAndUpload', 'upload'].contains(command) ||
-      buildMode == 'release') {
+  if (!['buildAndUpload', 'upload'].contains(command)) {
     quit(
       '$command is not a valid command, You can use either \'buildAndUpload\' or \'upload\'',
     );
@@ -75,8 +71,10 @@ For example:
 
   if (!fileSystemService.doesFileExist(pathToTestSweetsConfigsFile)) {
     throw BuildError(
-        'The folder at $flutterProjectFullPath does not contain a pubspec.yaml file. '
-        'Please check if this is the correct folder or create the pubspec.yaml file.');
+        '''Project config is not created . If you forgot to setup your .testsweets file please
+           create one. It requires three values, your projectId (found in your project settings)
+           your apiKey (found in your project settings) and your flutterBuildCommand (the part
+           of the command after flutter pub build apk).''');
   }
   final testSweetsConfigsSrc =
       fileSystemService.readFileAsStringSync(pathToTestSweetsConfigsFile);
@@ -90,7 +88,6 @@ For example:
   final buildInfo = await locator<BuildService>().build(
       flutterApp: flutterProjectFullPath,
       appType: appType,
-      buildMode: buildMode,
       pathToBuild: pathToBuild,
       extraFlutterProcessArgs: testSweetsConfigFileService
           .getValueFromConfigFileByKey(ConfigFileKeyType.FlutterBuildCommand)

--- a/packages/testsweets/bin/testsweets.dart
+++ b/packages/testsweets/bin/testsweets.dart
@@ -9,7 +9,13 @@ import '../lib/src/services/file_system_service.dart';
 import '../lib/src/services/upload_service.dart';
 
 Future<void> main(List<String> args) async {
-  final errorMessage =
+  void quit(
+    String errorMsg,
+  ) {
+    throw BuildError('Error: $errorMsg');
+  }
+
+  final _buildArgumentsError =
       '''Expected arguments to have the form: buildAndUpload appType buildMode projectId apiKey
 
 Where:
@@ -33,20 +39,17 @@ For example:
   \$ testsweets upload apk profile myProjectId myApiKey --path 'path/to/my/build.apk'
 ''';
 
-  void quit() {
-    print('Error: $errorMessage');
-    exit(-1);
-  }
-
-  if (args.length < 5) quit();
+  if (args.length < 2) quit(_buildArgumentsError);
 
   final command = args[0];
   final appType = args[1];
-  final buildMode = args[2];
+  final buildMode = '';
 
   if (!['buildAndUpload', 'upload'].contains(command) ||
       buildMode == 'release') {
-    quit();
+    quit(
+      '$command is not a valid command, You can use either \'buildAndUpload\' or \'upload\'',
+    );
   }
 
   String pathToBuild = '';
@@ -55,9 +58,9 @@ For example:
     if (positionBeforePath == -1) positionBeforePath = args.indexOf('-p');
 
     if (positionBeforePath == -1 || positionBeforePath == args.length) {
-      print(
-          "When using 'upload' you must provide the path to your build with the --path or -p argument after the apiKey\n\n");
-      quit();
+      quit(
+        "When using 'upload' you must provide the path to your build with the --path or -p argument after the apiKey\n\n",
+      );
     }
 
     pathToBuild = args[positionBeforePath + 1];
@@ -77,9 +80,12 @@ For example:
   }
   final testSweetsConfigsSrc =
       fileSystemService.readFileAsStringSync(pathToTestSweetsConfigsFile);
-  TestSweetsConfigFileService testSweetsConfigFileService =
+
+  locator.registerSingleton<TestSweetsConfigFileService>(
       TestSweetsConfigFileServiceImplementaion(
-          testSweetsConfigsFileSrc: testSweetsConfigsSrc);
+          testSweetsConfigsFileSrc: testSweetsConfigsSrc));
+
+  final testSweetsConfigFileService = locator<TestSweetsConfigFileService>();
 
   final buildInfo = await locator<BuildService>().build(
       flutterApp: flutterProjectFullPath,

--- a/packages/testsweets/lib/src/services/build_service.dart
+++ b/packages/testsweets/lib/src/services/build_service.dart
@@ -22,7 +22,6 @@ abstract class BuildService {
   Future<BuildInfo> build({
     required String flutterApp,
     required String appType,
-    required String buildMode,
     List<String> extraFlutterProcessArgs,
     String pathToBuild,
   });
@@ -41,7 +40,6 @@ class _BuildService implements BuildService {
   Future<BuildInfo> build({
     required String flutterApp,
     required String appType,
-    required String buildMode,
     List<String> extraFlutterProcessArgs = const <String>[],
     String pathToBuild = '',
   }) async {
@@ -79,8 +77,8 @@ class _BuildService implements BuildService {
     }
 
     if (pathToBuild.isEmpty) {
-      final runningFlutterProcess = await flutterProcess.startWith(
-          args: ['build', appType, '--$buildMode', ...extraFlutterProcessArgs]);
+      final runningFlutterProcess = await flutterProcess
+          .startWith(args: ['build', appType, ...extraFlutterProcessArgs]);
 
       final processStdoutCollector = Utf8CollectingStreamConsumer(stdout);
       final processStderrCollector = Utf8CollectingStreamConsumer(stderr);
@@ -99,7 +97,7 @@ class _BuildService implements BuildService {
     }
     return BuildInfo(
       pathToBuild: pathToBuild,
-      buildMode: buildMode,
+      buildMode: extraFlutterProcessArgs.first,
       appType: appType,
       version: pubspec['version'],
       automationKeysJson: appAutomationKeysJson,

--- a/packages/testsweets/lib/src/services/http_service.dart
+++ b/packages/testsweets/lib/src/services/http_service.dart
@@ -47,7 +47,7 @@ class _HttpService implements HttpService {
     final request = await HttpClient().putUrl(Uri.parse(to));
     headers.forEach((key, value) => request.headers.set(key, value));
 
-    // print('put binary headers: $headers');
+    print('');
 
     int numberOfBytesWritten = 0;
     Stopwatch counter = Stopwatch();
@@ -58,8 +58,10 @@ class _HttpService implements HttpService {
 
       if (counter.elapsed > Duration(seconds: 1)) {
         counter.reset();
-        print(
-            "Uploaded ${((numberOfBytesWritten / contentLength) * 100).ceil()}% of $contentLength");
+        //remove old progress print to the console
+        stdout.write("\r\x1b[K");
+        var progress = ((numberOfBytesWritten / contentLength) * 100).ceil();
+        stdout.write("Uploaded $progress% of $contentLength ...");
       }
 
       return chunk;

--- a/packages/testsweets/lib/src/services/test_sweets_config_file_service.dart
+++ b/packages/testsweets/lib/src/services/test_sweets_config_file_service.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+
+enum ConfigFileKeyType { ProjectId, ApiKey, FlutterBuildCommand }
+
+extension ToString on ConfigFileKeyType {
+  String get string => toString().split('.').last;
+}
+
+abstract class TestSweetsConfigFileService {
+  String getValueFromConfigFileByKey(ConfigFileKeyType keyType);
+}
+
+class TestSweetsConfigFileServiceImplementaion
+    implements TestSweetsConfigFileService {
+  final String testSweetsConfigsFileSrc;
+
+  const TestSweetsConfigFileServiceImplementaion(
+      {required this.testSweetsConfigsFileSrc});
+
+  @override
+  String getValueFromConfigFileByKey(ConfigFileKeyType keyType) {
+    return _deserializeConfigFileByKey(testSweetsConfigsFileSrc, keyType);
+  }
+
+  static dynamic _deserializeConfigFileByKey(
+      String src, ConfigFileKeyType keyType) {
+    final ls = LineSplitter();
+    final testSweetsConfigsCommands = ls.convert(src);
+
+    final map = _splittingStringOnEqualSign(testSweetsConfigsCommands);
+
+    switch (keyType) {
+      case ConfigFileKeyType.ProjectId:
+        return _getStringValueFromMapByKey(map, keyType);
+      case ConfigFileKeyType.ApiKey:
+        return _getStringValueFromMapByKey(map, keyType);
+      case ConfigFileKeyType.FlutterBuildCommand:
+        return _getStringValueFromMapByKey(map, keyType);
+      default:
+        return '';
+    }
+  }
+
+  static String _getStringValueFromMapByKey(
+      List<MapEntry<String, String>> map, ConfigFileKeyType keyType) {
+    return map.firstWhere((element) => element.key == keyType.string).value;
+  }
+
+  static List<MapEntry<String, String>> _splittingStringOnEqualSign(
+      List<String> testSweetsConfigsCommands) {
+    var map = testSweetsConfigsCommands.map((line) {
+      var listOfParts = line.split('=').map((part) => part.trim()).toList();
+      return MapEntry(listOfParts[0], listOfParts[1]);
+    }).toList();
+
+    return map;
+  }
+}

--- a/packages/testsweets/lib/src/services/test_sweets_config_file_service.dart
+++ b/packages/testsweets/lib/src/services/test_sweets_config_file_service.dart
@@ -37,8 +37,8 @@ class TestSweetsConfigFileServiceImplementaion
 
   String _getStringValueFromMapByKey(
       List<MapEntry<String, String>> map, ConfigFileKeyType keyType) {
-    print(
-        'key type: ${keyType.string}\n_getStringValueFromMapByKey: map = ${map.toString()}');
+    // print(
+    //     'key type: ${keyType.string}\n_getStringValueFromMapByKey: map = ${map.toString()}');
     return map.firstWhere((element) => element.key == keyType.string).value;
   }
 

--- a/packages/testsweets/lib/src/services/test_sweets_config_file_service.dart
+++ b/packages/testsweets/lib/src/services/test_sweets_config_file_service.dart
@@ -3,7 +3,11 @@ import 'dart:convert';
 enum ConfigFileKeyType { ProjectId, ApiKey, FlutterBuildCommand }
 
 extension ToString on ConfigFileKeyType {
-  String get string => toString().split('.').last;
+  String get string {
+    var lastPart = toString().split('.').last;
+    //convert to camelcase
+    return "${lastPart[0].toLowerCase()}${lastPart.substring(1)}";
+  }
 }
 
 abstract class TestSweetsConfigFileService {
@@ -22,31 +26,23 @@ class TestSweetsConfigFileServiceImplementaion
     return _deserializeConfigFileByKey(testSweetsConfigsFileSrc, keyType);
   }
 
-  static dynamic _deserializeConfigFileByKey(
-      String src, ConfigFileKeyType keyType) {
+  String _deserializeConfigFileByKey(String src, ConfigFileKeyType keyType) {
     final ls = LineSplitter();
     final testSweetsConfigsCommands = ls.convert(src);
 
     final map = _splittingStringOnEqualSign(testSweetsConfigsCommands);
 
-    switch (keyType) {
-      case ConfigFileKeyType.ProjectId:
-        return _getStringValueFromMapByKey(map, keyType);
-      case ConfigFileKeyType.ApiKey:
-        return _getStringValueFromMapByKey(map, keyType);
-      case ConfigFileKeyType.FlutterBuildCommand:
-        return _getStringValueFromMapByKey(map, keyType);
-      default:
-        return '';
-    }
+    return _getStringValueFromMapByKey(map, keyType);
   }
 
-  static String _getStringValueFromMapByKey(
+  String _getStringValueFromMapByKey(
       List<MapEntry<String, String>> map, ConfigFileKeyType keyType) {
+    print(
+        'key type: ${keyType.string}\n_getStringValueFromMapByKey: map = ${map.toString()}');
     return map.firstWhere((element) => element.key == keyType.string).value;
   }
 
-  static List<MapEntry<String, String>> _splittingStringOnEqualSign(
+  List<MapEntry<String, String>> _splittingStringOnEqualSign(
       List<String> testSweetsConfigsCommands) {
     var map = testSweetsConfigsCommands.map((line) {
       var listOfParts = line.split('=').map((part) => part.trim()).toList();

--- a/packages/testsweets/test/build_service_test.dart
+++ b/packages/testsweets/test/build_service_test.dart
@@ -101,8 +101,8 @@ void main() {
         getAndRegisterFileSystemService(doesFileExist: false);
 
         final instance = BuildService.makeInstance();
-        final run = () => instance.build(
-            flutterApp: directoryPath, appType: 'apk', buildMode: 'debug');
+        final run =
+            () => instance.build(flutterApp: directoryPath, appType: 'apk');
         expect(
             run(),
             throwsA(BuildError(
@@ -121,7 +121,9 @@ void main() {
 
         final instance = BuildService.makeInstance();
         final run = () => instance.build(
-            flutterApp: directoryPath, appType: 'apk', buildMode: 'debug');
+              flutterApp: directoryPath,
+              appType: 'apk',
+            );
         expect(
             run,
             throwsA(BuildError(
@@ -139,8 +141,8 @@ void main() {
         );
 
         final instance = BuildService.makeInstance();
-        final run = () => instance.build(
-            flutterApp: directoryPath, appType: 'apk', buildMode: 'debug');
+        final run =
+            () => instance.build(flutterApp: directoryPath, appType: 'apk');
         expect(
             run,
             throwsA(BuildError(
@@ -166,8 +168,7 @@ void main() {
         final flutterProcess = locator<FlutterProcess>();
 
         final instance = BuildService.makeInstance();
-        await instance.build(
-            flutterApp: directoryPath, appType: 'apk', buildMode: 'profile');
+        await instance.build(flutterApp: directoryPath, appType: 'apk');
 
         verify(() =>
                 flutterProcess.startWith(args: ['build', 'apk', '--profile']))
@@ -185,7 +186,6 @@ void main() {
         final buildInfo = await instance.build(
           flutterApp: directoryPath,
           appType: 'apk',
-          buildMode: 'profile',
           pathToBuild: pathToBuild,
         );
 
@@ -200,7 +200,9 @@ void main() {
             () async {
           final instance = BuildService.makeInstance();
           final buildInfo = await instance.build(
-              flutterApp: directoryPath, appType: 'apk', buildMode: 'profile');
+            flutterApp: directoryPath,
+            appType: 'apk',
+          );
 
           expect(buildInfo.pathToBuild,
               r'myApp\build\app\outputs\flutter-apk\abc.apk');
@@ -232,7 +234,9 @@ void main() {
 
           final instance = BuildService.makeInstance();
           final run = () => instance.build(
-              flutterApp: directoryPath, appType: 'apk', buildMode: 'profile');
+                flutterApp: directoryPath,
+                appType: 'apk',
+              );
 
           expect(
               run,


### PR DESCRIPTION
This PR is the result of this [spec](https://www.notion.so/filledstacks/Reduce-build-upload-requirements-25ec8262b73f4f6f886dac0532d779c0).
1. Replace apikey project id and build args with a .testsweet config file(see attached video).
2. Add an error message when you forgot to add a .testsweets file to the root of your project.
2. Fix inconsistency in console error messages.
3. Remove duplicated uploading messages in the console every time the progress increase(see attached photo).
4. Remove the build type field instead use the flutterBuildCommand from .testsweet file.


![Screenshot (95)](https://user-images.githubusercontent.com/84928835/122556287-fbc04480-d043-11eb-8786-9be660692047.png)

https://user-images.githubusercontent.com/84928835/122555478-03cbb480-d043-11eb-8b51-8f75aae4b7a6.mp4

