### PR TITLE
Feature/already-added-widget-inspection

### DIFF
--- a/packages/testsweets/lib/src/constants/app_constants.dart
+++ b/packages/testsweets/lib/src/constants/app_constants.dart
@@ -1,1 +1,1 @@
-const double WidgetDiscriptionVisualSize = 40;
+const double WidgetDescriptionVisualSize = 40;

--- a/packages/testsweets/lib/src/locator.dart
+++ b/packages/testsweets/lib/src/locator.dart
@@ -19,7 +19,7 @@ GetIt locator = GetIt.asNewInstance();
 bool locatorSetup = false;
 Future<void> setupLocator() async {
   locator
-      .registerLazySingleton<BuildService>(() => BuildServiceImplementaion());
+      .registerLazySingleton<BuildService>(() => BuildServiceImplementation());
   locator.registerLazySingleton<FlutterProcess>(
       () => FlutterProcess(Platform.isWindows ? 'flutter.bat' : 'flutter'));
   locator.registerLazySingleton<FileSystemService>(
@@ -33,8 +33,8 @@ Future<void> setupLocator() async {
       () => UploadServiceImplementation());
   locator.registerLazySingleton(() => DynamicKeysGenerator());
 
-  locator
-      .registerLazySingleton<TestSweetsConfigFileService>(()=> TestSweetsConfigFileService());
+  locator.registerLazySingleton<TestSweetsConfigFileService>(
+      () => TestSweetsConfigFileService());
 
   locator.registerLazySingleton<AutomationKeysService>(
       () => AutomationKeysServiceImplementation());

--- a/packages/testsweets/lib/src/services/build_service.dart
+++ b/packages/testsweets/lib/src/services/build_service.dart
@@ -27,7 +27,7 @@ abstract class BuildService {
   });
 }
 
-class BuildServiceImplementaion implements BuildService {
+class BuildServiceImplementation implements BuildService {
   final fileSystemService = locator<FileSystemService>();
   final flutterProcess = locator<FlutterProcess>();
 

--- a/packages/testsweets/lib/src/ui/driver_layout/driver_layout_view.dart
+++ b/packages/testsweets/lib/src/ui/driver_layout/driver_layout_view.dart
@@ -54,13 +54,13 @@ class DriverLayoutView extends StatelessWidget {
               ),
             ...model.descriptionsForView.map(
               (description) => Positioned(
-                top: description.position.y - (WidgetDiscriptionVisualSize / 2),
+                top: description.position.y - (WidgetDescriptionVisualSize / 2),
                 left:
-                    description.position.x - (WidgetDiscriptionVisualSize / 2),
+                    description.position.x - (WidgetDescriptionVisualSize / 2),
                 child: Container(
                   key: Key(description.automationKey),
-                  width: WidgetDiscriptionVisualSize,
-                  height: WidgetDiscriptionVisualSize,
+                  width: WidgetDescriptionVisualSize,
+                  height: WidgetDescriptionVisualSize,
                   decoration: BoxDecoration(
                     color: Color(0x01000000),
                     border: Border.all(color: Colors.red),

--- a/packages/testsweets/lib/src/ui/shared/shared_colors.dart
+++ b/packages/testsweets/lib/src/ui/shared/shared_colors.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/material.dart';
+
+const Color kcLightPink = const Color(0xFFEF6CCC);
+const Color kcMainButton = const Color(0xFF9690FE);

--- a/packages/testsweets/lib/src/ui/shared/shared_text_style.dart
+++ b/packages/testsweets/lib/src/ui/shared/shared_text_style.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+const boldStyle =
+    TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Colors.white);
+
+const lightStyle = TextStyle(fontSize: 18, color: Colors.white);
+
+const positionWidgetStyle =
+    TextStyle(fontSize: 40, fontWeight: FontWeight.bold, color: Colors.white);

--- a/packages/testsweets/lib/src/ui/shared/widgets/inspect_layout_widget.dart
+++ b/packages/testsweets/lib/src/ui/shared/widgets/inspect_layout_widget.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+import 'package:testsweets/src/constants/app_constants.dart';
+import 'package:testsweets/src/models/enums/widget_type.dart';
+import 'package:testsweets/src/ui/shared/shared_colors.dart';
+import 'package:testsweets/src/ui/shared/shared_text_style.dart';
+import 'package:testsweets/src/ui/widget_capture/widget_capture_viewmodel.dart';
+
+class InspectLayoutView extends ViewModelWidget<WidgetCaptureViewModel> {
+  const InspectLayoutView({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetCaptureViewModel model) {
+    return Expanded(
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: Container(
+              width: double.infinity,
+              height: double.infinity,
+              padding: const EdgeInsets.all(15),
+              decoration: BoxDecoration(
+                  border: Border.all(
+                color: kcLightPink,
+                width: 5,
+              )),
+            ),
+          ),
+          ...model.descriptionsForView.map(
+            (description) => Positioned(
+              top: description.position.y - (WidgetDescriptionVisualSize / 2),
+              left: description.position.x - (WidgetDescriptionVisualSize / 2),
+              child: IgnorePointer(
+                ignoring: model.ignorePointer,
+                child: GestureDetector(
+                  onTap: () {
+                    model.showWidgetDescription(description);
+                  },
+                  child: AnimatedOpacity(
+                    duration: const Duration(milliseconds: 300),
+                    opacity: model.activeWidgetId != description.id &&
+                            model.showDescription
+                        ? 0.25
+                        : 1,
+                    child: Container(
+                      key: Key(description.automationKey),
+                      width: WidgetDescriptionVisualSize,
+                      height: WidgetDescriptionVisualSize,
+                      decoration: BoxDecoration(
+                        color: description.widgetType == WidgetType.touchable
+                            ? kcLightPink
+                            : description.widgetType == WidgetType.input
+                                ? kcMainButton
+                                : Colors.red,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: description.widgetType == WidgetType.input
+                          ? Text('I')
+                          : description.widgetType == WidgetType.touchable
+                              ? Text('T',
+                                  textAlign: TextAlign.center,
+                                  style: positionWidgetStyle)
+                              : null,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/packages/testsweets/lib/src/ui/shared/widgets/inspect_layout_widget.dart
+++ b/packages/testsweets/lib/src/ui/shared/widgets/inspect_layout_widget.dart
@@ -13,64 +13,62 @@ class InspectLayoutView extends ViewModelWidget<WidgetCaptureViewModel> {
 
   @override
   Widget build(BuildContext context, WidgetCaptureViewModel model) {
-    return Expanded(
-      child: Stack(
-        children: [
-          Positioned.fill(
-            child: Container(
-              width: double.infinity,
-              height: double.infinity,
-              padding: const EdgeInsets.all(15),
-              decoration: BoxDecoration(
-                  border: Border.all(
-                color: kcLightPink,
-                width: 5,
-              )),
-            ),
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Container(
+            width: double.infinity,
+            height: double.infinity,
+            padding: const EdgeInsets.all(15),
+            decoration: BoxDecoration(
+                border: Border.all(
+              color: kcLightPink,
+              width: 5,
+            )),
           ),
-          ...model.descriptionsForView.map(
-            (description) => Positioned(
-              top: description.position.y - (WidgetDescriptionVisualSize / 2),
-              left: description.position.x - (WidgetDescriptionVisualSize / 2),
-              child: IgnorePointer(
-                ignoring: model.ignorePointer,
-                child: GestureDetector(
-                  onTap: () {
-                    model.showWidgetDescription(description);
-                  },
-                  child: AnimatedOpacity(
-                    duration: const Duration(milliseconds: 300),
-                    opacity: model.activeWidgetId != description.id &&
-                            model.showDescription
-                        ? 0.25
-                        : 1,
-                    child: Container(
-                      key: Key(description.automationKey),
-                      width: WidgetDescriptionVisualSize,
-                      height: WidgetDescriptionVisualSize,
-                      decoration: BoxDecoration(
-                        color: description.widgetType == WidgetType.touchable
-                            ? kcLightPink
-                            : description.widgetType == WidgetType.input
-                                ? kcMainButton
-                                : Colors.red,
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: description.widgetType == WidgetType.input
-                          ? Text('I')
-                          : description.widgetType == WidgetType.touchable
-                              ? Text('T',
-                                  textAlign: TextAlign.center,
-                                  style: positionWidgetStyle)
-                              : null,
+        ),
+        ...model.descriptionsForView.map(
+          (description) => Positioned(
+            top: description.position.y - (WidgetDescriptionVisualSize / 2),
+            left: description.position.x - (WidgetDescriptionVisualSize / 2),
+            child: IgnorePointer(
+              ignoring: model.ignorePointer,
+              child: GestureDetector(
+                onTap: () {
+                  model.showWidgetDescription(description);
+                },
+                child: AnimatedOpacity(
+                  duration: const Duration(milliseconds: 300),
+                  opacity: model.activeWidgetId != description.id &&
+                          model.showDescription
+                      ? 0.25
+                      : 1,
+                  child: Container(
+                    key: Key(description.automationKey),
+                    width: WidgetDescriptionVisualSize,
+                    height: WidgetDescriptionVisualSize,
+                    decoration: BoxDecoration(
+                      color: description.widgetType == WidgetType.touchable
+                          ? kcLightPink
+                          : description.widgetType == WidgetType.input
+                              ? kcMainButton
+                              : Colors.red,
+                      borderRadius: BorderRadius.circular(20),
                     ),
+                    child: description.widgetType == WidgetType.input
+                        ? Text('I')
+                        : description.widgetType == WidgetType.touchable
+                            ? Text('T',
+                                textAlign: TextAlign.center,
+                                style: positionWidgetStyle)
+                            : null,
                   ),
                 ),
               ),
             ),
-          )
-        ],
-      ),
+          ),
+        )
+      ],
     );
   }
 }

--- a/packages/testsweets/lib/src/ui/shared/widgets/widget_description_dialog_widget.dart
+++ b/packages/testsweets/lib/src/ui/shared/widgets/widget_description_dialog_widget.dart
@@ -17,42 +17,39 @@ class WidgetDescriptionDialog extends StatelessWidget {
     var positionY = description.position.y.toStringAsFixed(1);
     var widgetType = description.widgetType.toString().substring(11);
 
-    return Align(
-      alignment: Alignment.bottomCenter,
-      child: Container(
-        height: 250,
-        margin: EdgeInsets.only(bottom: 15, left: 12, right: 12),
-        padding: const EdgeInsets.symmetric(horizontal: 15),
-        child: SizedBox.expand(
-            child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text('Widget Description', style: boldStyle),
-                IconButton(
-                  icon: Icon(
-                    Icons.cancel,
-                    color: Colors.grey,
-                    size: 32,
-                  ),
-                  onPressed: onPressed,
-                ),
-              ],
+    return Container(
+      height: 250,
+      width: 390,
+      margin: EdgeInsets.symmetric(horizontal: 12),
+      padding: const EdgeInsets.symmetric(horizontal: 15),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+      Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text('Widget Description', style: boldStyle),
+          IconButton(
+            icon: Icon(
+              Icons.cancel,
+              color: Colors.grey,
+              size: 32,
             ),
-            Text('View Name: ${description.viewName}', style: lightStyle),
-            Text('Name: ${description.name}', style: lightStyle),
-            Text('Widget Type: ${widgetType.capitalizeFirst}',
-                style: lightStyle),
-            Text('Position: (x:$positionX, y:$positionY)', style: lightStyle),
-          ],
-        )),
-        decoration: BoxDecoration(
-          color: Color(0xFF181920),
-          borderRadius: BorderRadius.circular(10),
-        ),
+            onPressed: onPressed,
+          ),
+        ],
+      ),
+      Text('View Name: ${description.viewName}', style: lightStyle),
+      Text('Name: ${description.name}', style: lightStyle),
+      Text('Widget Type: ${widgetType.capitalizeFirst}',
+          style: lightStyle),
+      Text('Position: (x:$positionX, y:$positionY)', style: lightStyle),
+        ],
+      ),
+      decoration: BoxDecoration(
+        color: Color(0xFF181920),
+        borderRadius: BorderRadius.circular(10),
       ),
     );
   }

--- a/packages/testsweets/lib/src/ui/shared/widgets/widget_description_dialog_widget.dart
+++ b/packages/testsweets/lib/src/ui/shared/widgets/widget_description_dialog_widget.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:stacked_services/stacked_services.dart';
+import 'package:testsweets/src/models/application_models.dart';
+import 'package:testsweets/src/ui/shared/shared_text_style.dart';
+
+class WidgetDescriptionDialog extends StatelessWidget {
+  final WidgetDescription description;
+  final VoidCallback onPressed;
+
+  const WidgetDescriptionDialog(
+      {Key? key, required this.description, required this.onPressed})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    var positionX = description.position.x.toStringAsFixed(1);
+    var positionY = description.position.y.toStringAsFixed(1);
+    var widgetType = description.widgetType.toString().substring(11);
+
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: Container(
+        height: 250,
+        margin: EdgeInsets.only(bottom: 15, left: 12, right: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 15),
+        child: SizedBox.expand(
+            child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Widget Description', style: boldStyle),
+                IconButton(
+                  icon: Icon(
+                    Icons.cancel,
+                    color: Colors.grey,
+                    size: 32,
+                  ),
+                  onPressed: onPressed,
+                ),
+              ],
+            ),
+            Text('View Name: ${description.viewName}', style: lightStyle),
+            Text('Name: ${description.name}', style: lightStyle),
+            Text('Widget Type: ${widgetType.capitalizeFirst}',
+                style: lightStyle),
+            Text('Position: (x:$positionX, y:$positionY)', style: lightStyle),
+          ],
+        )),
+        decoration: BoxDecoration(
+          color: Color(0xFF181920),
+          borderRadius: BorderRadius.circular(10),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
@@ -151,16 +151,11 @@ class WidgetCaptureView extends StatelessWidget with $WidgetCaptureView {
                 ),
                 AnimatedPositioned(
                   duration: Duration(milliseconds: 500),
-                  child: AnimatedSwitcher(
-                      duration: Duration(milliseconds: 500),
-                      switchInCurve: Curves.bounceIn,
-                      switchOutCurve: Curves.bounceOut,
-                      child: model.showDescription
-                          ? WidgetDescriptionDialog(
-                              description: model.activeWidgetDescription,
-                              onPressed: model.closeWidgetDescription,
-                            )
-                          : SizedBox.shrink()),
+                  bottom: model.showDescription ? 20 : -300,
+                  child: WidgetDescriptionDialog(
+                    description: model.activeWidgetDescription,
+                    onPressed: model.closeWidgetDescription,
+                  ),
                 )
               ],
             ),

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
@@ -151,10 +151,15 @@ class WidgetCaptureView extends StatelessWidget with $WidgetCaptureView {
                 ),
                 AnimatedPositioned(
                   duration: Duration(milliseconds: 500),
-                  bottom: model.showDescription ? 20 : -300,
-                  child: WidgetDescriptionDialog(
-                    description: model.activeWidgetDescription,
-                    onPressed: model.closeWidgetDescription,
+                  bottom: model.showDescription ? 20 : -200,
+                  child: AnimatedSwitcher(
+                    duration: Duration(milliseconds: 500),
+                    child: model.showDescription
+                        ? WidgetDescriptionDialog(
+                            description: model.activeWidgetDescription,
+                            onPressed: model.closeWidgetDescription,
+                          )
+                        : SizedBox.shrink(),
                   ),
                 )
               ],

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
@@ -30,7 +30,7 @@ class WidgetCaptureView extends StatelessWidget with $WidgetCaptureView {
           model.setWidgetNameFocused(widgetNameFocusNode.hasFocus);
         });
         SchedulerBinding.instance?.addPostFrameCallback((timeStamp) {
-          model.initialise(projectId);
+          model.initialise(projectId: projectId);
         });
       },
       builder: (context, model, _) => Overlay(

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
@@ -5,6 +5,7 @@ import 'package:stacked/stacked_annotations.dart';
 import 'package:testsweets/src/constants/app_constants.dart';
 import 'package:testsweets/src/ui/shared/shared_colors.dart';
 import 'package:testsweets/src/ui/shared/widgets/inspect_layout_widget.dart';
+import 'package:testsweets/src/ui/shared/widgets/widget_description_dialog_widget.dart';
 import 'package:testsweets/src/ui/widget_capture/widget_capture_view.form.dart';
 import 'package:testsweets/src/ui/widget_capture/widget_capture_viewmodel.dart';
 
@@ -148,6 +149,19 @@ class WidgetCaptureView extends StatelessWidget with $WidgetCaptureView {
                     ],
                   ),
                 ),
+                AnimatedPositioned(
+                  duration: Duration(milliseconds: 500),
+                  child: AnimatedSwitcher(
+                      duration: Duration(milliseconds: 500),
+                      switchInCurve: Curves.bounceIn,
+                      switchOutCurve: Curves.bounceOut,
+                      child: model.showDescription
+                          ? WidgetDescriptionDialog(
+                              description: model.activeWidgetDescription,
+                              onPressed: model.closeWidgetDescription,
+                            )
+                          : SizedBox.shrink()),
+                )
               ],
             ),
           ),

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked/stacked_annotations.dart';
 import 'package:testsweets/src/constants/app_constants.dart';
+import 'package:testsweets/src/ui/shared/shared_colors.dart';
+import 'package:testsweets/src/ui/shared/widgets/inspect_layout_widget.dart';
 import 'package:testsweets/src/ui/widget_capture/widget_capture_view.form.dart';
 import 'package:testsweets/src/ui/widget_capture/widget_capture_viewmodel.dart';
 
@@ -25,101 +28,129 @@ class WidgetCaptureView extends StatelessWidget with $WidgetCaptureView {
         widgetNameFocusNode.addListener(() {
           model.setWidgetNameFocused(widgetNameFocusNode.hasFocus);
         });
+        SchedulerBinding.instance?.addPostFrameCallback((timeStamp) {
+          model.initialise(projectId);
+        });
       },
       builder: (context, model, _) => Overlay(
         initialEntries: [
           OverlayEntry(
-              builder: (context) => Stack(
+            builder: (context) => Stack(
+              children: [
+                child,
+                if (model.inspectLayoutEnable) InspectLayoutView(),
+                if (!model.hasWidgetDescription &&
+                    model.captureViewEnabled &&
+                    !model.inspectLayoutEnable)
+                  _WidgetDescriptionCaptureLayer(),
+                if (model.hasWidgetDescription &&
+                    model.captureViewEnabled &&
+                    !model.inspectLayoutEnable)
+                  Positioned.fill(
+                    child: Container(
+                      width: double.infinity,
+                      height: double.infinity,
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: Colors.pink,
+                          width: 5,
+                        ),
+                      ),
+                    ),
+                  ),
+                if (model.hasWidgetDescription &&
+                    model.captureViewEnabled &&
+                    !model.inspectLayoutEnable)
+                  Positioned(
+                      top: model.descriptionTop,
+                      left: model.descriptionLeft,
+                      child: GestureDetector(
+                        onPanUpdate: (panEvent) {
+                          final x = panEvent.delta.dx;
+                          final y = panEvent.delta.dy;
+                          model.updateDescriptionPosition(x, y);
+                        },
+                        child: Container(
+                          width: WidgetDescriptionVisualSize,
+                          height: WidgetDescriptionVisualSize,
+                          decoration: BoxDecoration(
+                            color: Colors.pink,
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                        ),
+                      )),
+                if (model.hasWidgetDescription &&
+                    model.captureViewEnabled &&
+                    !model.inspectLayoutEnable)
+                  AnimatedPositioned(
+                    duration: const Duration(milliseconds: 500),
+                    curve: Curves.easeInCubic,
+                    left: 10,
+                    bottom: model.hasWidgetNameFocus ? null : 20,
+                    top: model.hasWidgetNameFocus ? 20 : null,
+                    child: SizedBox(
+                      width: 150,
+                      child: TextField(
+                        focusNode: widgetNameFocusNode,
+                        controller: widgetNameController,
+                        decoration:
+                            InputDecoration(hintText: 'Enter widget name'),
+                      ),
+                    ),
+                  ),
+                Positioned(
+                  bottom: 20,
+                  right: 20,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.max,
+                    mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      child,
-                      if (!model.hasWidgetDesription &&
-                          model.captureViewEnabled)
-                        _WidgetDescriptionCaptureLayer(),
-                      if (model.hasWidgetDesription && model.captureViewEnabled)
-                        Positioned.fill(
-                          child: Container(
-                            width: double.infinity,
-                            height: double.infinity,
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                color: Colors.pink,
-                                width: 5,
-                              ),
+                      if (!model.captureViewEnabled)
+                        Column(
+                          children: [
+                            MaterialButton(
+                              onPressed: model.toggleInspectLayout,
+                              color: kcLightPink,
+                              child: Text('Inspect View',
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                  )),
                             ),
-                          ),
-                        ),
-                      if (model.hasWidgetDesription && model.captureViewEnabled)
-                        Positioned(
-                            top: model.descriptionTop,
-                            left: model.descriptionLeft,
-                            child: GestureDetector(
-                              onPanUpdate: (panEvent) {
-                                final x = panEvent.delta.dx;
-                                final y = panEvent.delta.dy;
-                                model.updateDescriptionPosition(x, y);
-                              },
-                              child: Container(
-                                width: WidgetDiscriptionVisualSize,
-                                height: WidgetDiscriptionVisualSize,
-                                decoration: BoxDecoration(
-                                  color: Colors.pink,
-                                  borderRadius: BorderRadius.circular(20),
-                                ),
-                              ),
-                            )),
-                      if (model.hasWidgetDesription && model.captureViewEnabled)
-                        AnimatedPositioned(
-                          duration: const Duration(milliseconds: 500),
-                          curve: Curves.easeInCubic,
-                          left: 10,
-                          bottom: model.hasWidgetNameFocus ? null : 20,
-                          top: model.hasWidgetNameFocus ? 20 : null,
-                          child: SizedBox(
-                            width: 150,
-                            child: TextField(
-                              focusNode: widgetNameFocusNode,
-                              controller: widgetNameController,
-                              decoration: InputDecoration(
-                                  hintText: 'Enter widget name'),
+                            MaterialButton(
+                              onPressed: model.toggleCaptureView,
+                              color: kcMainButton,
+                              child: Text('Start Capture',
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                  )),
                             ),
-                          ),
+                          ],
                         ),
-                      Positioned(
-                          bottom: 20,
-                          right: 20,
-                          child: Row(
-                            mainAxisSize: MainAxisSize.max,
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            children: [
-                              if (!model.captureViewEnabled)
-                                MaterialButton(
-                                  onPressed: model.toggleCaptureView,
-                                  color: Colors.green,
-                                  child: Text('Capture Widget'),
-                                ),
-                              if (model.captureViewEnabled)
-                                Column(
-                                  children: [
-                                    MaterialButton(
-                                      onPressed: model.toggleCaptureView,
-                                      color: Colors.red,
-                                      child: Text('Stop Capture'),
-                                    ),
-                                    if (model.captureViewEnabled &&
-                                        model.hasWidgetDesription)
-                                      MaterialButton(
-                                        color: Colors.pinkAccent,
-                                        child: model.isBusy
-                                            ? CircularProgressIndicator()
-                                            : Text('Save Widget'),
-                                        onPressed: model.saveWidgetDescription,
-                                      )
-                                  ],
-                                ),
-                            ],
-                          ))
+                      if (model.captureViewEnabled)
+                        Column(
+                          children: [
+                            MaterialButton(
+                              onPressed: model.toggleCaptureView,
+                              color: Colors.red,
+                              child: Text('Stop Capture'),
+                            ),
+                            if (model.captureViewEnabled &&
+                                model.hasWidgetDescription)
+                              MaterialButton(
+                                color: Colors.pinkAccent,
+                                child: model.isBusy
+                                    ? CircularProgressIndicator()
+                                    : Text('Save Widget'),
+                                onPressed: model.saveWidgetDescription,
+                              )
+                          ],
+                        ),
                     ],
-                  ))
+                  ),
+                ),
+              ],
+            ),
+          ),
         ],
       ),
       viewModelBuilder: () => WidgetCaptureViewModel(projectId: projectId),

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
@@ -22,7 +22,7 @@ class WidgetCaptureViewModel extends FormViewModel {
         currentRoute: _testSweetsRouteTracker.currentRoute,
       );
 
-  Future<void> initialise(String projectId) async {
+  Future<void> initialise({required String projectId}) async {
     setBusy(true);
     try {
       await _widgetCaptureService.loadWidgetDescriptionsForProject(

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
@@ -3,6 +3,7 @@ import 'package:testsweets/src/app/logger.dart';
 import 'package:testsweets/src/constants/app_constants.dart';
 import 'package:testsweets/src/locator.dart';
 import 'package:testsweets/src/models/application_models.dart';
+import 'package:testsweets/src/models/enums/widget_type.dart';
 import 'package:testsweets/src/services/testsweets_route_tracker.dart';
 import 'package:testsweets/src/services/widget_capture_service.dart';
 
@@ -119,6 +120,38 @@ class WidgetCaptureViewModel extends FormViewModel {
 
   void setWidgetNameFocused(bool hasFocus) {
     _hasWidgetNameFocus = hasFocus;
+    notifyListeners();
+  }
+
+  bool _showDescription = false;
+  bool get showDescription => _showDescription;
+
+  String _activeWidgetId = '';
+  String get activeWidgetId => _activeWidgetId;
+
+  bool _ignorePointer = false;
+  bool get ignorePointer => _ignorePointer;
+
+  WidgetDescription _activeWidgetDescription = WidgetDescription(
+    name: '',
+    position: WidgetPosition(x: 0, y: 0),
+    viewName: '',
+    widgetType: WidgetType.touchable,
+  );
+  WidgetDescription get activeWidgetDescription => _activeWidgetDescription;
+
+  void showWidgetDescription(WidgetDescription description) {
+    _activeWidgetDescription = description;
+    _activeWidgetId = description.id ?? '';
+    _showDescription = !_showDescription;
+    _ignorePointer = !_ignorePointer;
+    notifyListeners();
+  }
+
+  void closeWidgetDescription() {
+    _activeWidgetId = '';
+    _showDescription = false;
+    _ignorePointer = false;
     notifyListeners();
   }
 }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
@@ -16,6 +16,23 @@ class WidgetCaptureViewModel extends FormViewModel {
   final _testSweetsRouteTracker = locator<TestSweetsRouteTracker>();
   final _widgetCaptureService = locator<WidgetCaptureService>();
 
+  List<WidgetDescription> get descriptionsForView =>
+      _widgetCaptureService.getDescriptionsForView(
+        currentRoute: _testSweetsRouteTracker.currentRoute,
+      );
+
+  Future<void> initialise(String projectId) async {
+    setBusy(true);
+    try {
+      await _widgetCaptureService.loadWidgetDescriptionsForProject(
+        projectId: projectId,
+      );
+    } catch (e) {
+      log.e('Could not get widgetDescriptions: $e');
+    }
+    setBusy(false);
+  }
+
   WidgetDescription? _widgetDescription;
   bool _hasWidgetNameFocus = false;
   bool _captureViewEnabled = false;
@@ -28,13 +45,13 @@ class WidgetCaptureViewModel extends FormViewModel {
 
   WidgetDescription get widgetDescription => _widgetDescription!;
 
-  bool get hasWidgetDesription => _widgetDescription != null;
+  bool get hasWidgetDescription => _widgetDescription != null;
 
   double get descriptionTop =>
-      _widgetDescription!.position.y - (WidgetDiscriptionVisualSize / 2);
+      _widgetDescription!.position.y - (WidgetDescriptionVisualSize / 2);
 
   double get descriptionLeft =>
-      _widgetDescription!.position.x - (WidgetDiscriptionVisualSize / 2);
+      _widgetDescription!.position.x - (WidgetDescriptionVisualSize / 2);
 
   void addWidgetAtTap({required double x, required double y}) {
     log.i('x:$x y:$y');

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
@@ -64,6 +64,15 @@ class WidgetCaptureViewModel extends FormViewModel {
 
   void toggleCaptureView() {
     _captureViewEnabled = !_captureViewEnabled;
+    _inspectLayoutEnable = false;
+    notifyListeners();
+  }
+
+  bool _inspectLayoutEnable = false;
+  bool get inspectLayoutEnable => _inspectLayoutEnable;
+
+  void toggleInspectLayout() {
+    _inspectLayoutEnable = !_inspectLayoutEnable;
     notifyListeners();
   }
 

--- a/packages/testsweets/test/build_service_test.dart
+++ b/packages/testsweets/test/build_service_test.dart
@@ -17,7 +17,7 @@ void main() {
       test(
           "Should throw BuildError if the given app directory does not contain a pubspec.yaml file",
           () async {
-        final buildService = BuildServiceImplementaion();
+        final buildService = BuildServiceImplementation();
 
         ;
         expect(
@@ -32,7 +32,7 @@ void main() {
             doesFileExist: true,
             readFileAsStringSyncResult: ksPubspecFileWithNoVersion,
             jsonFilesreadFileAsStringSyncResult: appAutomationKeysFile);
-        final buildService = BuildServiceImplementaion();
+        final buildService = BuildServiceImplementation();
 
         expect(
             () => buildService.build(
@@ -56,7 +56,7 @@ void main() {
 
         final flutterProcess = locator<FlutterProcess>();
 
-        final instance = BuildServiceImplementaion();
+        final instance = BuildServiceImplementation();
         await instance.build(
             appType: testAppType, extraFlutterProcessArgs: testExtraArgs);
 
@@ -72,7 +72,7 @@ void main() {
           readFileAsStringSyncResult: ksPubspecFileWithVersion,
           jsonFilesreadFileAsStringSyncResult: appAutomationKeysFile,
         );
-        final instance = BuildServiceImplementaion();
+        final instance = BuildServiceImplementation();
         final buildInfo = await instance.build(
             appType: testAppType,
             pathToBuild: testPathToBuild,
@@ -90,7 +90,7 @@ void main() {
           readFileAsStringSyncResult: ksPubspecFileWithVersion,
           jsonFilesreadFileAsStringSyncResult: appAutomationKeysFile,
         );
-        final instance = BuildServiceImplementaion();
+        final instance = BuildServiceImplementation();
         final buildInfo = await instance.build(
             appType: testAppType, extraFlutterProcessArgs: testExtraArgs);
 
@@ -105,7 +105,7 @@ void main() {
       test(
           "When the flutterProcess completes with a non 0 exit code, Should throw BuildError with the contents of stderr of the flutter process as the message",
           () async {
-        final instance = BuildServiceImplementaion();
+        final instance = BuildServiceImplementation();
         final run = () => instance.build(
               appType: testAppType,
             );

--- a/packages/testsweets/test/helpers/test_helpers.dart
+++ b/packages/testsweets/test/helpers/test_helpers.dart
@@ -10,6 +10,7 @@ import 'package:testsweets/src/services/file_system_service.dart';
 import 'package:testsweets/src/services/http_service.dart';
 import 'package:testsweets/src/services/runnable_process.dart';
 import 'package:testsweets/src/services/test_sweets_config_file_service.dart';
+import 'package:testsweets/src/services/testsweets_route_tracker.dart';
 import 'package:testsweets/src/services/time_service.dart';
 import 'package:testsweets/src/services/upload_service.dart';
 import 'package:testsweets/src/services/widget_capture_service.dart';
@@ -30,6 +31,7 @@ import 'test_helpers.mocks.dart';
   MockSpec<UploadService>(returnNullOnMissingStub: true),
   MockSpec<AutomationKeysService>(returnNullOnMissingStub: true),
   MockSpec<WidgetCaptureService>(returnNullOnMissingStub: true),
+  MockSpec<TestSweetsRouteTracker>(returnNullOnMissingStub: true),
 ])
 MockFileSystemService getAndRegisterFileSystemService({
   bool doesFileExist = false,
@@ -208,6 +210,13 @@ AutomationKeysService getAndRegisterAutomationKeysService() {
   return service;
 }
 
+MockTestSweetsRouteTracker getAndRegisterTestSweetsRouteTracker() {
+  _removeRegistrationIfExists<TestSweetsRouteTracker>();
+  final service = MockTestSweetsRouteTracker();
+  locator.registerSingleton<TestSweetsRouteTracker>(service);
+  return service;
+}
+
 void registerServices() {
   getAndRegisterFileSystemService();
   getAndRegisterFlutterProcess();
@@ -219,6 +228,8 @@ void registerServices() {
   getAndRegisterTestSweetsConfigFileService();
   getAndRegisterUploadService();
   getAndRegisterAutomationKeysService();
+  getAndRegisterTestSweetsRouteTracker();
+  getAndRegisterWidgetCaptureService();
 }
 
 void unregisterServices() {
@@ -232,6 +243,8 @@ void unregisterServices() {
   locator.unregister<TestSweetsConfigFileService>();
   locator.unregister<UploadService>();
   locator.unregister<AutomationKeysService>();
+  locator.unregister<TestSweetsRouteTracker>();
+  locator.unregister<WidgetCaptureService>();
 }
 
 // Call this before any service registration helper. This is to ensure that if there

--- a/packages/testsweets/test/helpers/test_helpers.mocks.dart
+++ b/packages/testsweets/test/helpers/test_helpers.mocks.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async' as _i9;
 import 'dart:io' as _i4;
+import 'dart:ui' as _i19;
 
 import 'package:logger/src/logger.dart' as _i6;
 import 'package:mockito/mockito.dart' as _i1;
@@ -18,6 +19,7 @@ import 'package:testsweets/src/services/http_service.dart' as _i5;
 import 'package:testsweets/src/services/runnable_process.dart' as _i10;
 import 'package:testsweets/src/services/test_sweets_config_file_service.dart'
     as _i7;
+import 'package:testsweets/src/services/testsweets_route_tracker.dart' as _i18;
 import 'package:testsweets/src/services/time_service.dart' as _i11;
 import 'package:testsweets/src/services/upload_service.dart' as _i15;
 import 'package:testsweets/src/services/widget_capture_service.dart' as _i17;
@@ -340,6 +342,42 @@ class MockWidgetCaptureService extends _i1.Mock
                   #getDescriptionsForView, [], {#currentRoute: currentRoute}),
               returnValue: <_i13.WidgetDescription>[])
           as List<_i13.WidgetDescription>);
+  @override
+  String toString() => super.toString();
+}
+
+/// A class which mocks [TestSweetsRouteTracker].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockTestSweetsRouteTracker extends _i1.Mock
+    implements _i18.TestSweetsRouteTracker {
+  @override
+  String get currentRoute =>
+      (super.noSuchMethod(Invocation.getter(#currentRoute), returnValue: '')
+          as String);
+  @override
+  bool get hasListeners =>
+      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
+          as bool);
+  @override
+  void setCurrentRoute(String? route) =>
+      super.noSuchMethod(Invocation.method(#setCurrentRoute, [route]),
+          returnValueForMissingStub: null);
+  @override
+  void addListener(_i19.VoidCallback? listener) =>
+      super.noSuchMethod(Invocation.method(#addListener, [listener]),
+          returnValueForMissingStub: null);
+  @override
+  void removeListener(_i19.VoidCallback? listener) =>
+      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
+          returnValueForMissingStub: null);
+  @override
+  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
+      returnValueForMissingStub: null);
+  @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
   @override
   String toString() => super.toString();
 }

--- a/packages/testsweets/test/view_models/widget_capture_viewmodel_test.dart
+++ b/packages/testsweets/test/view_models/widget_capture_viewmodel_test.dart
@@ -1,0 +1,103 @@
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'package:testsweets/src/locator.dart';
+import 'package:testsweets/src/models/application_models.dart';
+import 'package:testsweets/src/models/enums/widget_type.dart';
+import 'package:testsweets/src/ui/widget_capture/widget_capture_viewmodel.dart';
+
+import '../helpers/test_helpers.dart';
+
+void main() {
+  group('WidgetCaptureViewModelTest -', () {
+    setUp(() => registerServices());
+    tearDown(() => locator.reset());
+
+    group('initialize -', () {
+      test('When called, should set viewmodel busy', () async {
+        final projectId = 'testSweets Id';
+
+        final model = WidgetCaptureViewModel(projectId: projectId);
+
+        model.initialise(projectId: projectId);
+
+        expect(model.isBusy, true);
+      });
+      test('When called, should get all widget description for project',
+          () async {
+        final service = getAndRegisterWidgetCaptureService();
+        final projectId = 'testSweets Id';
+
+        final model = WidgetCaptureViewModel(projectId: projectId);
+
+        await model.initialise(projectId: projectId);
+
+        verify(service.loadWidgetDescriptionsForProject(projectId: projectId));
+      });
+    });
+
+    group('showWidgetDescription -', () {
+      test(
+          'When called, should set the active widget description to the current widget description',
+          () async {
+        final description = WidgetDescription(
+          id: 'widgetId',
+          viewName: 'login',
+          name: 'email',
+          position: WidgetPosition(x: 100, y: 199),
+          widgetType: WidgetType.general,
+        );
+
+        final projectId = 'testSweets Id';
+
+        final model = WidgetCaptureViewModel(projectId: projectId);
+
+        model.showWidgetDescription(description);
+
+        expect(model.activeWidgetDescription, description);
+        expect(model.activeWidgetId, description.id);
+      });
+
+      test(
+          'When called, should set widget description and ignore pointer boolean value be true',
+          () async {
+        final description = WidgetDescription(
+          viewName: 'login',
+          name: 'email',
+          position: WidgetPosition(x: 100, y: 199),
+          widgetType: WidgetType.general,
+        );
+
+        final projectId = 'testSweets Id';
+        final model = WidgetCaptureViewModel(projectId: projectId);
+
+        model.showWidgetDescription(description);
+
+        expect(model.showDescription, isTrue);
+        expect(model.ignorePointer, isTrue);
+      });
+    });
+
+    group('closeWidgetDescription -', () {
+      test('When called, should set the active widgetId to empty', () async {
+        final projectId = 'testSweets Id';
+        final model = WidgetCaptureViewModel(projectId: projectId);
+
+        model.closeWidgetDescription();
+
+        expect(model.activeWidgetId, isEmpty);
+      });
+
+      test(
+          'When called, should set widget description and ignore pointer boolean value be false',
+          () async {
+        final projectId = 'testSweets Id';
+        final model = WidgetCaptureViewModel(projectId: projectId);
+
+        model.closeWidgetDescription();
+
+        expect(model.showDescription, isFalse);
+        expect(model.ignorePointer, isFalse);
+      });
+    });
+  });
+}

--- a/packages/testsweets_generator/example/pubspec.lock
+++ b/packages/testsweets_generator/example/pubspec.lock
@@ -414,7 +414,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.4.1"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR adds functionality to view widgets key's added for inspection and widgets details.

**Task completed ✅** 

- [x]  Add a button above the "Start Capture" button called "Inspect View".
- [x]  When tapped we show all the added widget descriptions for that view.
- [x]  When tapping on one of those descriptions we bring up the widget details dialog at the bottom.
    - [x]  We show all the widget details.
- [x]  Tapping close on that dialog removes it.
- [x]  When a widget is in focus, we set an opacity of 0.25 on all the other widget descriptions.
- [x]  We have different stylings for each widget description.
    - [x]  Input is #9690FE with a capital I in the center.
    - [x]  Touchable is #F0276F with a capital T in the center.
- [x] use ` AnimatedOpacity` for widgets to fade in/out.
- [x] Slide in and out using ` AnimatedPositioned` when showing description.


### **Preview of the Feature Added**
<a href="https://www.loom.com/share/2c3b5a517d424bd68bf781ff03d00bea">
    <p>Feature - Already-added-widget-inspection - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/2c3b5a517d424bd68bf781ff03d00bea-with-play.gif">
  </a>