### PR TITLE
Allow user to add scroll widgets for capturing

### DIFF
--- a/packages/testsweets/example/lib/main.dart
+++ b/packages/testsweets/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'app/app.router.dart';
 
 const bool FLUTTER_DRIVER = bool.fromEnvironment(
   'FLUTTER_DRIVER',
-  defaultValue: true,
+  defaultValue: false,
 );
 
 Future<void> main() async {
@@ -30,7 +30,7 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
       ),
       builder: (context, child) => TestSweetsOverlayView(
-        projectId: '5EEL6eC4M7DK80Tu49bd',
+        projectId: '3sTkrgNYFWtSqDka2AqK',
         child: child!,
         captureWidgets: true,
       ),

--- a/packages/testsweets/example/lib/ui/login/login_view.dart
+++ b/packages/testsweets/example/lib/ui/login/login_view.dart
@@ -8,17 +8,59 @@ class LoginView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    List<Color> colorItems = [
+      Colors.blue,
+      Colors.red,
+      Colors.green,
+      Colors.purple,
+      Colors.orange,
+      Colors.black,
+    ];
+
     return ViewModelBuilder<LoginViewModel>.reactive(
       builder: (context, model, child) => Scaffold(
-        body: Center(
-          child: MaterialButton(
-            color: Colors.blue,
-            child: Text(
-              'Go to Home',
-              style: TextStyle(color: Colors.red),
+        body: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            Container(
+              height: 150,
+              child: Scrollbar(
+                isAlwaysShown: true,
+                child: ListView.builder(
+                  itemCount: colorItems.length,
+                  scrollDirection: Axis.horizontal,
+                  padding: EdgeInsets.all(10),
+                  itemBuilder: (context, index) => Container(
+                    width: 150,
+                    color: colorItems[index],
+                  ),
+                ),
+              ),
             ),
-            onPressed: model.navigateToOtherView,
-          ),
+            Center(
+              child: MaterialButton(
+                color: Colors.blue,
+                child: Text(
+                  'Go to Home',
+                  style: TextStyle(color: Colors.red),
+                ),
+                onPressed: model.navigateToOtherView,
+              ),
+            ),
+            Container(
+              height: 200,
+              child: Scrollbar(
+                child: ListView.builder(
+                  itemCount: colorItems.length,
+                  padding: EdgeInsets.all(10),
+                  itemBuilder: (context, index) => Container(
+                    height: 50,
+                    color: colorItems[index],
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
       viewModelBuilder: () => LoginViewModel(),

--- a/packages/testsweets/lib/src/services/widget_capture_service.dart
+++ b/packages/testsweets/lib/src/services/widget_capture_service.dart
@@ -61,5 +61,7 @@ class WidgetCaptureService {
   }
 
   bool checkCurrentViewIfAlreadyCaptured(String viewName) =>
-      widgetDescriptionMap[viewName]!.any((element) => element.name == '');
+      widgetDescriptionMap.containsKey(viewName)
+          ? widgetDescriptionMap[viewName]!.any((element) => element.name == '')
+          : false;
 }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
@@ -53,7 +53,7 @@ class WidgetCaptureView extends StatelessWidget with $WidgetCaptureView {
                                     widgetNameFocusNode: widgetNameFocusNode),
                               if (model.captureWidgetStatusEnum ==
                                   CaptureWidgetStatusEnum.idle)
-                                Expanded(child: IntroControllers()),
+                                IntroControllers(),
                               Positioned(
                                   bottom: 20,
                                   child: Container(

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
@@ -51,6 +51,9 @@ class WidgetCaptureView extends StatelessWidget with $WidgetCaptureView {
                                 CaptureLayout(
                                     widgetNameController: widgetNameController,
                                     widgetNameFocusNode: widgetNameFocusNode),
+                              if (model.captureWidgetStatusEnum ==
+                                  CaptureWidgetStatusEnum.idle)
+                                Expanded(child: IntroControllers()),
                               Positioned(
                                   bottom: 20,
                                   child: Container(
@@ -61,9 +64,6 @@ class WidgetCaptureView extends StatelessWidget with $WidgetCaptureView {
                                       mainAxisSize: MainAxisSize.max,
                                       mainAxisAlignment: MainAxisAlignment.end,
                                       children: [
-                                        if (model.captureWidgetStatusEnum ==
-                                            CaptureWidgetStatusEnum.idle)
-                                          IntroControllers(),
                                         if (model.captureWidgetStatusEnum ==
                                             CaptureWidgetStatusEnum.inspectMode)
                                           CtaButton(

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
@@ -158,17 +158,22 @@ class WidgetCaptureViewModel extends FormViewModel {
         widgetType: widgetType, widgetPosition: widgetPosition);
 
     if (!_widgetCaptureService.checkCurrentViewIfAlreadyCaptured(
-        _testSweetsRouteTracker.currentRoute))
+        _testSweetsRouteTracker.currentRoute)) {
+      setBusy(true);
       await _captureViewWhenItsNotAlreadyCaptured();
+      setBusy(false);
+    }
 
     _showInputTextField();
   }
 
-  Future<void> _captureViewWhenItsNotAlreadyCaptured() async =>
-      await _widgetCaptureService.captureWidgetDescription(
-          description:
-              WidgetDescription.addView(_testSweetsRouteTracker.currentRoute),
-          projectId: projectId);
+  Future<void> _captureViewWhenItsNotAlreadyCaptured() async {
+    await _widgetCaptureService.captureWidgetDescription(
+        description:
+            WidgetDescription.addView(_testSweetsRouteTracker.currentRoute),
+        projectId: projectId);
+    await initialise(projectId: projectId);
+  }
 
   void _showInputTextField() {
     toggleWidgetsContainer();

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/black_wrapper_container.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/black_wrapper_container.dart
@@ -8,59 +8,94 @@ import 'package:testsweets/src/ui/widget_capture/widget_capture_widgets/close_ci
 class BlackWrapperContainer extends StatelessWidget {
   final bool bottomCornersAreFlat;
   final VoidCallback switchPositionTap;
-  final VoidCallback closeWidget;
+  final VoidCallback? closeWidget;
   final Widget child;
+  final Widget? footerChild;
   const BlackWrapperContainer(
       {Key? key,
       this.bottomCornersAreFlat = false,
       required this.switchPositionTap,
-      required this.closeWidget,
-      required this.child})
+      this.closeWidget,
+      required this.child,
+      this.footerChild})
       : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding:
-          EdgeInsets.only(left: 16.w, right: 16.w, top: 12.h, bottom: 20.h),
-      decoration: blackBoxDecoration.copyWith(
-          borderRadius: bottomCornersAreFlat
-              ? BorderRadius.vertical(top: crButtonCornerRadius())
-              : null),
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: 12.w,
+      ).copyWith(
+          top: 32.h, bottom: MediaQuery.of(context).viewInsets.bottom + 24.h),
       child: Column(
-        mainAxisSize: MainAxisSize.min,
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              TextButton.icon(
-                onPressed: switchPositionTap,
-                style: ButtonStyle(
-                  shape: MaterialStateProperty.all<OutlinedBorder>(
-                      RoundedRectangleBorder(
-                          borderRadius:
-                              BorderRadius.all(crTextFieldCornerRadius()))),
-                  backgroundColor: MaterialStateProperty.all(kcPrimaryFuchsia),
+          Container(
+            padding: EdgeInsets.only(
+                left: 16.w, right: 16.w, top: 12.h, bottom: 20.h),
+            decoration: blackBoxDecoration.copyWith(
+                borderRadius: bottomCornersAreFlat
+                    ? BorderRadius.vertical(top: crButtonCornerRadius())
+                    : null),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextButton.icon(
+                      onPressed: switchPositionTap,
+                      style: ButtonStyle(
+                        shape: MaterialStateProperty.all<OutlinedBorder>(
+                            RoundedRectangleBorder(
+                                borderRadius: BorderRadius.all(
+                                    crTextFieldCornerRadius()))),
+                        backgroundColor:
+                            MaterialStateProperty.all(kcSweetsAppBarColor),
+                      ),
+                      icon: Icon(
+                        Icons.swap_vert,
+                        size: 16.w,
+                        color: kcPrimaryWhite,
+                      ),
+                      label: AutoSizeText('Switch Position',
+                          maxLines: 1,
+                          style: tsNormal()
+                              .copyWith(color: Colors.white, fontSize: 14.w)),
+                    ),
+                    closeWidget != null
+                        ? CloseCircularButton(onTap: closeWidget!)
+                        : const SizedBox()
+                  ],
                 ),
-                icon: Icon(
-                  Icons.swap_vert,
-                  size: 16.w,
-                  color: kcPrimaryWhite,
+                SizedBox(
+                  height: 24.w,
                 ),
-                label: AutoSizeText('Switch Position',
-                    maxLines: 1,
-                    style: tsNormal()
-                        .copyWith(color: Colors.white, fontSize: 14.w)),
-              ),
-              GestureDetector(onTap: closeWidget, child: CloseCircularButton())
-            ],
+                child,
+              ],
+            ),
           ),
-          SizedBox(
-            height: 24.w,
-          ),
-          child
+          footerChild ?? const SizedBox()
         ],
       ),
+    );
+  }
+}
+
+class BlackContainerAlignAnimation extends StatelessWidget {
+  final Widget child;
+  final bool isDown;
+  const BlackContainerAlignAnimation(
+      {Key? key, required this.child, this.isDown = true})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedAlign(
+      duration: const Duration(milliseconds: 500),
+      curve: Curves.easeOutCubic,
+      alignment: isDown ? Alignment.bottomCenter : Alignment.topCenter,
+      widthFactor: 1,
+      child: child,
     );
   }
 }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/black_wrapper_container.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/black_wrapper_container.dart
@@ -1,0 +1,66 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:testsweets/src/ui/shared/app_colors.dart';
+import 'package:testsweets/src/ui/shared/shared_styles.dart';
+import 'package:testsweets/src/ui/widget_capture/widget_capture_widgets/close_circular_button.dart';
+
+class BlackWrapperContainer extends StatelessWidget {
+  final bool bottomCornersAreFlat;
+  final VoidCallback switchPositionTap;
+  final VoidCallback closeWidget;
+  final Widget child;
+  const BlackWrapperContainer(
+      {Key? key,
+      this.bottomCornersAreFlat = false,
+      required this.switchPositionTap,
+      required this.closeWidget,
+      required this.child})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding:
+          EdgeInsets.only(left: 16.w, right: 16.w, top: 12.h, bottom: 20.h),
+      decoration: blackBoxDecoration.copyWith(
+          borderRadius: bottomCornersAreFlat
+              ? BorderRadius.vertical(top: crButtonCornerRadius())
+              : null),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              TextButton.icon(
+                onPressed: switchPositionTap,
+                style: ButtonStyle(
+                  shape: MaterialStateProperty.all<OutlinedBorder>(
+                      RoundedRectangleBorder(
+                          borderRadius:
+                              BorderRadius.all(crTextFieldCornerRadius()))),
+                  backgroundColor: MaterialStateProperty.all(kcPrimaryFuchsia),
+                ),
+                icon: Icon(
+                  Icons.swap_vert,
+                  size: 16.w,
+                  color: kcPrimaryWhite,
+                ),
+                label: AutoSizeText('Switch Position',
+                    maxLines: 1,
+                    style: tsNormal()
+                        .copyWith(color: Colors.white, fontSize: 14.w)),
+              ),
+              GestureDetector(onTap: closeWidget, child: CloseCircularButton())
+            ],
+          ),
+          SizedBox(
+            height: 24.w,
+          ),
+          child
+        ],
+      ),
+    );
+  }
+}

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/black_wrapper_container.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/black_wrapper_container.dart
@@ -6,76 +6,86 @@ import 'package:testsweets/src/ui/shared/shared_styles.dart';
 import 'package:testsweets/src/ui/widget_capture/widget_capture_widgets/close_circular_button.dart';
 
 class BlackWrapperContainer extends StatelessWidget {
-  final bool bottomCornersAreFlat;
-  final VoidCallback switchPositionTap;
+  final VoidCallback? switchPositionTap;
   final VoidCallback? closeWidget;
   final Widget child;
   final Widget? footerChild;
+  final double? spaceBetweenTopControllersAndChild;
   const BlackWrapperContainer(
       {Key? key,
-      this.bottomCornersAreFlat = false,
-      required this.switchPositionTap,
+      this.switchPositionTap,
       this.closeWidget,
       required this.child,
-      this.footerChild})
+      this.footerChild,
+      this.spaceBetweenTopControllersAndChild})
       : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.symmetric(
-        horizontal: 12.w,
-      ).copyWith(
-          top: 32.h, bottom: MediaQuery.of(context).viewInsets.bottom + 24.h),
-      child: Column(
-        children: [
-          Container(
-            padding: EdgeInsets.only(
-                left: 16.w, right: 16.w, top: 12.h, bottom: 20.h),
-            decoration: blackBoxDecoration.copyWith(
-                borderRadius: bottomCornersAreFlat
-                    ? BorderRadius.vertical(top: crButtonCornerRadius())
-                    : null),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    TextButton.icon(
-                      onPressed: switchPositionTap,
-                      style: ButtonStyle(
-                        shape: MaterialStateProperty.all<OutlinedBorder>(
-                            RoundedRectangleBorder(
-                                borderRadius: BorderRadius.all(
-                                    crTextFieldCornerRadius()))),
-                        backgroundColor:
-                            MaterialStateProperty.all(kcSweetsAppBarColor),
-                      ),
-                      icon: Icon(
-                        Icons.swap_vert,
-                        size: 16.w,
-                        color: kcPrimaryWhite,
-                      ),
-                      label: AutoSizeText('Switch Position',
-                          maxLines: 1,
-                          style: tsNormal()
-                              .copyWith(color: Colors.white, fontSize: 14.w)),
-                    ),
-                    closeWidget != null
-                        ? CloseCircularButton(onTap: closeWidget!)
-                        : const SizedBox()
-                  ],
-                ),
-                SizedBox(
-                  height: 24.w,
-                ),
-                child,
-              ],
+    return SizedBox(
+      width: ScreenUtil().screenWidth,
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: 12.w,
+        ).copyWith(
+            top: 32.h, bottom: MediaQuery.of(context).viewInsets.bottom + 24.h),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: EdgeInsets.only(
+                  left: 16.w, right: 16.w, top: 12.h, bottom: 20.h),
+              decoration: blackBoxDecoration.copyWith(
+                  borderRadius: footerChild != null
+                      ? BorderRadius.vertical(top: crButtonCornerRadius())
+                      : null),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      switchPositionTap != null
+                          ? TextButton.icon(
+                              onPressed: switchPositionTap,
+                              style: ButtonStyle(
+                                shape:
+                                    MaterialStateProperty.all<OutlinedBorder>(
+                                        RoundedRectangleBorder(
+                                            borderRadius: BorderRadius.all(
+                                                crTextFieldCornerRadius()))),
+                                backgroundColor: MaterialStateProperty.all(
+                                    kcSweetsAppBarColor),
+                              ),
+                              icon: Icon(
+                                Icons.swap_vert,
+                                size: 16.w,
+                                color: kcPrimaryWhite,
+                              ),
+                              label: AutoSizeText('Switch Position',
+                                  maxLines: 1,
+                                  style: tsNormal().copyWith(
+                                      color: Colors.white, fontSize: 14.w)),
+                            )
+                          : const SizedBox(),
+                      closeWidget != null
+                          ? CloseCircularButton(onTap: closeWidget!)
+                          : const SizedBox()
+                    ],
+                  ),
+                  SizedBox(
+                    height: spaceBetweenTopControllersAndChild ?? 24.w,
+                  ),
+                  child,
+                ],
+              ),
             ),
-          ),
-          footerChild ?? const SizedBox()
-        ],
+            footerChild ?? const SizedBox()
+          ],
+        ),
       ),
     );
   }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/close_circular_button.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/close_circular_button.dart
@@ -1,26 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:testsweets/src/ui/shared/app_colors.dart';
 
 class CloseCircularButton extends StatelessWidget {
-  const CloseCircularButton({Key? key}) : super(key: key);
+  final VoidCallback? onTap;
+  const CloseCircularButton({Key? key, this.onTap}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      alignment: Alignment.center,
-      children: [
-        Icon(
-          Icons.circle,
-          color: kcSecondaryWhite,
-          size: 28.w,
-        ),
-        Icon(
-          Icons.close,
-          color: kcCard,
-          size: 14.w,
-        ),
-      ],
+    return IconButton(
+      icon: Icon(
+        Icons.cancel,
+        color: kcSweetsAppBarColor,
+        size: 32,
+      ),
+      onPressed: onTap,
     );
   }
 }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/close_circular_button.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/close_circular_button.dart
@@ -11,7 +11,7 @@ class CloseCircularButton extends StatelessWidget {
       icon: Icon(
         Icons.cancel,
         color: kcSweetsAppBarColor,
-        size: 32,
+        size: 34,
       ),
       onPressed: onTap,
     );

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/inspect_controllers.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/inspect_controllers.dart
@@ -43,7 +43,9 @@ class InspectControllers extends ViewModelWidget<WidgetCaptureViewModel> {
                           ? kcError
                           : description.widgetType == WidgetType.input
                               ? kcPrimaryPurple
-                              : Colors.red,
+                              : description.widgetType == WidgetType.scrollable
+                                  ? kcSecondaryGreen
+                                  : Colors.red,
                     ),
                     child: description.widgetType == WidgetType.input
                         ? Text('I',
@@ -53,7 +55,11 @@ class InspectControllers extends ViewModelWidget<WidgetCaptureViewModel> {
                             ? Text('T',
                                 textAlign: TextAlign.center,
                                 style: positionWidgetStyle)
-                            : null,
+                            : description.widgetType == WidgetType.scrollable
+                                ? Text('S',
+                                    textAlign: TextAlign.center,
+                                    style: positionWidgetStyle)
+                                : null,
                   ),
                 ),
               ),

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/intro_controllers.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/intro_controllers.dart
@@ -13,26 +13,34 @@ class IntroControllers extends ViewModelWidget<WidgetCaptureViewModel> {
 
   @override
   Widget build(BuildContext context, WidgetCaptureViewModel model) {
-    return BlackWrapperContainer(
-      switchPositionTap: model.switchWidgetNameInputPosition,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          CtaButton(
-            title: 'Inspect View',
-            fillColor: kcPrimaryFuchsia,
-            onTap: model.toggleInspectLayout,
-          ),
-          const SizedBox(
-            height: 16,
-          ),
-          CtaButton(
-            title: 'Start Capture',
-            fillColor: kcPrimaryPurple,
-            onTap: model.toggleCaptureView,
-          ),
-        ],
+    return AnimatedAlign(
+      duration: const Duration(milliseconds: 500),
+      curve: Curves.easeOutCubic,
+      alignment: model.widgetNameInputPositionIsDown
+          ? Alignment.bottomCenter
+          : Alignment.topCenter,
+      widthFactor: 1,
+      child: BlackWrapperContainer(
+        switchPositionTap: model.switchWidgetNameInputPosition,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            CtaButton(
+              title: 'Inspect View',
+              fillColor: kcPrimaryFuchsia,
+              onTap: model.toggleInspectLayout,
+            ),
+            const SizedBox(
+              height: 16,
+            ),
+            CtaButton(
+              title: 'Start Capture',
+              fillColor: kcPrimaryPurple,
+              onTap: model.toggleCaptureView,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/intro_controllers.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/intro_controllers.dart
@@ -4,6 +4,7 @@ import 'package:testsweets/src/ui/shared/app_colors.dart';
 import 'package:testsweets/src/ui/shared/cta_button.dart';
 
 import '../widget_capture_viewmodel.dart';
+import 'black_wrapper_container.dart';
 
 class IntroControllers extends ViewModelWidget<WidgetCaptureViewModel> {
   const IntroControllers({
@@ -12,23 +13,27 @@ class IntroControllers extends ViewModelWidget<WidgetCaptureViewModel> {
 
   @override
   Widget build(BuildContext context, WidgetCaptureViewModel model) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.end,
-      children: [
-        CtaButton(
-          title: 'Inspect View',
-          fillColor: kcPrimaryFuchsia,
-          onTap: model.toggleInspectLayout,
-        ),
-        const SizedBox(
-          height: 16,
-        ),
-        CtaButton(
-          title: 'Start Capture',
-          fillColor: kcPrimaryPurple,
-          onTap: model.toggleCaptureView,
-        ),
-      ],
+    return BlackWrapperContainer(
+      switchPositionTap: model.switchWidgetNameInputPosition,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          CtaButton(
+            title: 'Inspect View',
+            fillColor: kcPrimaryFuchsia,
+            onTap: model.toggleInspectLayout,
+          ),
+          const SizedBox(
+            height: 16,
+          ),
+          CtaButton(
+            title: 'Start Capture',
+            fillColor: kcPrimaryPurple,
+            onTap: model.toggleCaptureView,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/multi_style_text.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/multi_style_text.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:testsweets/src/ui/shared/app_colors.dart';
+import 'package:testsweets/src/ui/shared/shared_styles.dart';
+
+class MultiStyleText extends StatelessWidget {
+  final String title;
+  final String body;
+  const MultiStyleText({Key? key, required this.title, required this.body})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text.rich(
+      TextSpan(children: [
+        TextSpan(
+            style: lightStyle.copyWith(color: kcPrimaryPurple), text: title),
+        TextSpan(
+            style: lightStyle.copyWith(
+              color: body.isEmpty ? kcError : kcPrimaryWhite,
+            ),
+            text: body.isEmpty ? '(empty)' : body),
+      ]),
+    );
+  }
+}

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_description_dialog.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_description_dialog.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:stacked/stacked.dart';
 import 'package:testsweets/src/ui/shared/shared_styles.dart';
 import 'package:testsweets/src/ui/widget_capture/widget_capture_viewmodel.dart';
+
+import 'black_wrapper_container.dart';
+import 'multi_style_text.dart';
 
 class WidgetDescriptionDialog extends ViewModelWidget<WidgetCaptureViewModel> {
   const WidgetDescriptionDialog({
@@ -12,44 +16,45 @@ class WidgetDescriptionDialog extends ViewModelWidget<WidgetCaptureViewModel> {
   Widget build(BuildContext context, WidgetCaptureViewModel model) {
     final description = model.activeWidgetDescription;
 
-    return Container(
-      height: 250,
-      width: 390,
-      margin: EdgeInsets.symmetric(horizontal: 12),
-      padding: const EdgeInsets.symmetric(horizontal: 15),
+    return BlackWrapperContainer(
+      closeWidget: model.closeWidgetDescription,
+      spaceBetweenTopControllersAndChild: 0,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text('Widget Description', style: boldStyle),
-              IconButton(
-                icon: Icon(
-                  Icons.cancel,
-                  color: Colors.grey,
-                  size: 32,
-                ),
-                onPressed: model.closeWidgetDescription,
-              ),
-            ],
+          Text('Widget Description', style: boldStyle),
+          SizedBox(
+            height: 8.h,
           ),
-          if (description != null) ...[
-            Text('View Name: ${description.viewName}', style: lightStyle),
-            Text('Name: ${description.name}', style: lightStyle),
-            Text(
-                'Widget Type: ${description.widgetType.toString().substring(11).capitalizeFirstofEach}',
-                style: lightStyle),
-            Text(
-                'Position: (x:${description.position.x.toStringAsFixed(1)}, y:${description.position.y.toStringAsFixed(1)})',
-                style: lightStyle),
-          ]
+          if (description != null)
+            ...[
+              MultiStyleText(
+                title: 'View Name: ',
+                body: description.viewName,
+              ),
+              MultiStyleText(
+                title: 'Name: ',
+                body: description.name,
+              ),
+              MultiStyleText(
+                title: 'Widget Type: ',
+                body: description.widgetType
+                    .toString()
+                    .substring(11)
+                    .capitalizeFirstofEach,
+              ),
+              MultiStyleText(
+                title: 'Position: ',
+                body:
+                    '( x: ${description.position.x.toStringAsFixed(1)}, y: ${description.position.y.toStringAsFixed(1)} )',
+              ),
+            ].expand((element) => [
+                  element,
+                  SizedBox(
+                    height: 3.h,
+                  )
+                ])
         ],
-      ),
-      decoration: BoxDecoration(
-        color: Color(0xFF181920),
-        borderRadius: BorderRadius.circular(10),
       ),
     );
   }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_name_input.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_name_input.dart
@@ -26,84 +26,77 @@ class WidgetNameInput extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.symmetric(
-        horizontal: 12.w,
-      ).copyWith(
-          top: 32.h, bottom: MediaQuery.of(context).viewInsets.bottom + 24.h),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          BlackWrapperContainer(
-            bottomCornersAreFlat: errorMessage.isNotEmpty,
-            switchPositionTap: switchPositionTap,
-            closeWidget: closeWidget,
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    focusNode: focusNode,
-                    controller: textEditingController,
-                    style: tsNormal().copyWith(color: kcPrimaryWhite),
-                    decoration: InputDecoration(
-                        hintStyle: tsNormal().copyWith(
-                          color: kcSecondaryWhite,
-                        ),
-                        fillColor: kcBackground,
-                        filled: true,
-                        hintText: 'Widget Name',
-                        contentPadding: EdgeInsets.only(
-                          left: 16.w,
-                          right: 16.w,
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderSide: BorderSide(
-                            width: 1.w,
-                            color: kcSecondaryGreen,
-                          ),
-                          borderRadius: BorderRadius.all(
-                            crTextFieldCornerRadius(),
-                          ),
-                        ),
-                        enabledBorder: OutlineInputBorder(
-                          borderSide: BorderSide(
-                            width: 1.w,
-                            color: kcBackground,
-                          ),
-                          borderRadius: BorderRadius.all(
-                            crTextFieldCornerRadius(),
-                          ),
-                        )),
-                  ),
-                ),
-                SizedBox(
-                  width: 12.w,
-                ),
-                CtaButton(
-                  title: 'Save Widget',
-                  fillColor: kcSecondaryGreen,
-                  onTap: () {
-                    saveWidget();
-                    focusNode?.unfocus();
-                    textEditingController?.clear();
-                  },
-                  maxWidth: 100.w,
-                ),
-              ],
-            ),
-          ),
-          FadeInWidget(
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        BlackWrapperContainer(
+          bottomCornersAreFlat: errorMessage.isNotEmpty,
+          switchPositionTap: switchPositionTap,
+          closeWidget: closeWidget,
+          footerChild: FadeInWidget(
               child: Container(
                 width: ScreenUtil().screenWidth,
-                padding:
-                    const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
+                padding: EdgeInsets.symmetric(vertical: 12, horizontal: 16.w),
                 decoration: redBoxDecoration,
                 child: AutoSizeText(errorMessage,
                     style: tsSmall().copyWith(color: kcPrimaryWhite)),
               ),
-              isVisible: errorMessage.isNotEmpty)
-        ],
-      ),
+              isVisible: errorMessage.isNotEmpty),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  focusNode: focusNode,
+                  controller: textEditingController,
+                  style: tsNormal().copyWith(color: kcPrimaryWhite),
+                  decoration: InputDecoration(
+                      hintStyle: tsNormal().copyWith(
+                        color: kcSecondaryWhite,
+                      ),
+                      fillColor: kcSweetsAppBarColor,
+                      filled: true,
+                      hintText: 'Widget Name',
+                      contentPadding: EdgeInsets.only(
+                        left: 16.w,
+                        right: 16.w,
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderSide: BorderSide(
+                          width: 1.w,
+                          color: kcSecondaryGreen,
+                        ),
+                        borderRadius: BorderRadius.all(
+                          crTextFieldCornerRadius(),
+                        ),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderSide: BorderSide(
+                          width: 1.w,
+                          color: kcBackground,
+                        ),
+                        borderRadius: BorderRadius.all(
+                          crTextFieldCornerRadius(),
+                        ),
+                      )),
+                ),
+              ),
+              SizedBox(
+                width: 12.w,
+              ),
+              CtaButton(
+                title: 'Save Widget',
+                fillColor: kcSecondaryGreen,
+                onTap: () {
+                  saveWidget();
+                  focusNode?.unfocus();
+                  textEditingController?.clear();
+                },
+                maxWidth: 100.w,
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_name_input.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_name_input.dart
@@ -4,7 +4,8 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:testsweets/src/ui/shared/app_colors.dart';
 import 'package:testsweets/src/ui/shared/cta_button.dart';
 import 'package:testsweets/src/ui/shared/shared_styles.dart';
-import 'package:testsweets/src/ui/widget_capture/widget_capture_widgets/close_circular_button.dart';
+
+import 'black_wrapper_container.dart';
 
 class WidgetNameInput extends StatelessWidget {
   final FocusNode? focusNode;
@@ -33,98 +34,60 @@ class WidgetNameInput extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            padding: EdgeInsets.only(
-                left: 16.w, right: 16.w, top: 12.h, bottom: 20.h),
-            decoration: blackBoxDecoration.copyWith(
-                borderRadius: errorMessage.isNotEmpty
-                    ? BorderRadius.vertical(top: crButtonCornerRadius())
-                    : null),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
+          BlackWrapperContainer(
+            bottomCornersAreFlat: errorMessage.isNotEmpty,
+            switchPositionTap: switchPositionTap,
+            closeWidget: closeWidget,
+            child: Row(
               children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    TextButton.icon(
-                      onPressed: switchPositionTap,
-                      style: ButtonStyle(
-                        shape: MaterialStateProperty.all<OutlinedBorder>(
-                            RoundedRectangleBorder(
-                                borderRadius: BorderRadius.all(
-                                    crTextFieldCornerRadius()))),
-                        backgroundColor:
-                            MaterialStateProperty.all(kcPrimaryFuchsia),
-                      ),
-                      icon: Icon(
-                        Icons.swap_vert,
-                        size: 16.w,
-                        color: kcPrimaryWhite,
-                      ),
-                      label: AutoSizeText('Switch Position',
-                          maxLines: 1,
-                          style: tsNormal()
-                              .copyWith(color: Colors.white, fontSize: 14.w)),
-                    ),
-                    GestureDetector(
-                        onTap: closeWidget, child: CloseCircularButton())
-                  ],
+                Expanded(
+                  child: TextField(
+                    focusNode: focusNode,
+                    controller: textEditingController,
+                    style: tsNormal().copyWith(color: kcPrimaryWhite),
+                    decoration: InputDecoration(
+                        hintStyle: tsNormal().copyWith(
+                          color: kcSecondaryWhite,
+                        ),
+                        fillColor: kcBackground,
+                        filled: true,
+                        hintText: 'Widget Name',
+                        contentPadding: EdgeInsets.only(
+                          left: 16.w,
+                          right: 16.w,
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderSide: BorderSide(
+                            width: 1.w,
+                            color: kcSecondaryGreen,
+                          ),
+                          borderRadius: BorderRadius.all(
+                            crTextFieldCornerRadius(),
+                          ),
+                        ),
+                        enabledBorder: OutlineInputBorder(
+                          borderSide: BorderSide(
+                            width: 1.w,
+                            color: kcBackground,
+                          ),
+                          borderRadius: BorderRadius.all(
+                            crTextFieldCornerRadius(),
+                          ),
+                        )),
+                  ),
                 ),
                 SizedBox(
-                  height: 24.w,
+                  width: 12.w,
                 ),
-                Row(
-                  children: [
-                    Expanded(
-                      child: TextField(
-                        focusNode: focusNode,
-                        controller: textEditingController,
-                        style: tsNormal().copyWith(color: kcPrimaryWhite),
-                        decoration: InputDecoration(
-                            hintStyle: tsNormal().copyWith(
-                              color: kcSecondaryWhite,
-                            ),
-                            fillColor: kcBackground,
-                            filled: true,
-                            hintText: 'Widget Name',
-                            contentPadding: EdgeInsets.only(
-                              left: 16.w,
-                              right: 16.w,
-                            ),
-                            focusedBorder: OutlineInputBorder(
-                              borderSide: BorderSide(
-                                width: 1.w,
-                                color: kcSecondaryGreen,
-                              ),
-                              borderRadius: BorderRadius.all(
-                                crTextFieldCornerRadius(),
-                              ),
-                            ),
-                            enabledBorder: OutlineInputBorder(
-                              borderSide: BorderSide(
-                                width: 1.w,
-                                color: kcBackground,
-                              ),
-                              borderRadius: BorderRadius.all(
-                                crTextFieldCornerRadius(),
-                              ),
-                            )),
-                      ),
-                    ),
-                    SizedBox(
-                      width: 12.w,
-                    ),
-                    CtaButton(
-                      title: 'Save Widget',
-                      fillColor: kcSecondaryGreen,
-                      onTap: () {
-                        saveWidget();
-                        focusNode?.unfocus();
-                        textEditingController?.clear();
-                      },
-                      maxWidth: 100.w,
-                    ),
-                  ],
+                CtaButton(
+                  title: 'Save Widget',
+                  fillColor: kcSecondaryGreen,
+                  onTap: () {
+                    saveWidget();
+                    focusNode?.unfocus();
+                    textEditingController?.clear();
+                  },
+                  maxWidth: 100.w,
                 ),
               ],
             ),

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_name_input.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_name_input.dart
@@ -30,7 +30,6 @@ class WidgetNameInput extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         BlackWrapperContainer(
-          bottomCornersAreFlat: errorMessage.isNotEmpty,
           switchPositionTap: switchPositionTap,
           closeWidget: closeWidget,
           footerChild: FadeInWidget(

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_types_container.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_types_container.dart
@@ -43,6 +43,16 @@ class WidgetsTypesContainer extends ViewModelWidget<WidgetCaptureViewModel> {
           SizedBox(
             height: 24.w,
           ),
+          _WidgetTypeButton(
+            onTap: () => model.addNewWidget(WidgetType.scrollable,
+                widgetPosition: WidgetPosition(
+                    x: ScreenUtil().screenWidth / 2,
+                    y: ScreenUtil().screenHeight / 2)),
+            title: 'Scrollable',
+          ),
+          SizedBox(
+            height: 24.w,
+          ),
           Divider(
             color: kcBackground,
             thickness: 5.w,

--- a/packages/testsweets/test/helpers/test_helpers.dart
+++ b/packages/testsweets/test/helpers/test_helpers.dart
@@ -75,7 +75,8 @@ MockWidgetCaptureService getAndRegisterWidgetCaptureService(
   final service = MockWidgetCaptureService();
 
   when(service.captureWidgetDescription(
-          description: description, projectId: projectId))
+          description: anyNamed('description'),
+          projectId: anyNamed('projectId')))
       .thenAnswer((realInvocation) => Future.value());
   when(service.getDescriptionsForView(currentRoute: anyNamed('currentRoute')))
       .thenReturn(listOfWidgetDescription);


### PR DESCRIPTION
This PR adds the new scrollable widget and identify it in the inspect view.

- [x]  Add the scroll widget into the widget container
- [x]  Add a new "S" widget description indicator into the view when Scroll is selected
- [x]  Add scroll demo to Example UI.

### **PREVIEW:**

<a href="https://www.loom.com/share/5eff7e4e3c844aea9dcc2679b9fdbb3d">
    <p>Allow user to add scroll widgets for capturing - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/5eff7e4e3c844aea9dcc2679b9fdbb3d-with-play.gif">
  </a>

