### PR TITLE
Fix bottom navigator bar preventing tracker

### DIFF
--- a/packages/testsweets/example/lib/app/app.dart
+++ b/packages/testsweets/example/lib/app/app.dart
@@ -1,6 +1,7 @@
 import 'package:example/ui/home/home_view.dart';
 import 'package:example/ui/home/signup_view.dart';
 import 'package:example/ui/login/login_view.dart';
+import 'package:example/ui/main/main_view.dart';
 import 'package:stacked/stacked_annotations.dart';
 import 'package:stacked_services/stacked_services.dart';
 
@@ -12,6 +13,7 @@ import 'package:stacked_services/stacked_services.dart';
     ),
     MaterialRoute(page: LoginView),
     MaterialRoute(page: HomeView),
+    MaterialRoute(page: MainView),
   ],
   dependencies: [
     LazySingleton(classType: NavigationService),

--- a/packages/testsweets/example/lib/app/app.logger.dart
+++ b/packages/testsweets/example/lib/app/app.logger.dart
@@ -62,8 +62,8 @@ class SimpleLogPrinter extends LogPrinter {
       var currentStack = StackTrace.current;
       var formattedStacktrace = _formatStackTrace(currentStack, 3);
 
-      var realFirstLine = formattedStacktrace
-          ?.firstWhere((line) => line.contains(className), orElse: () => "");
+      var realFirstLine =
+          formattedStacktrace?.firstWhere((line) => line.contains(className));
 
       var methodName = realFirstLine?.replaceAll('$className.', '');
       return methodName;

--- a/packages/testsweets/example/lib/app/app.router.dart
+++ b/packages/testsweets/example/lib/app/app.router.dart
@@ -12,15 +12,18 @@ import 'package:stacked/stacked.dart';
 import '../ui/home/home_view.dart';
 import '../ui/home/signup_view.dart';
 import '../ui/login/login_view.dart';
+import '../ui/main/main_view.dart';
 
 class Routes {
   static const String signUpView = '/';
   static const String loginView = '/login-view';
   static const String homeView = '/home-view';
+  static const String mainView = '/main-view';
   static const all = <String>{
     signUpView,
     loginView,
     homeView,
+    mainView,
   };
 }
 
@@ -31,6 +34,7 @@ class StackedRouter extends RouterBase {
     RouteDef(Routes.signUpView, page: SignUpView),
     RouteDef(Routes.loginView, page: LoginView),
     RouteDef(Routes.homeView, page: HomeView),
+    RouteDef(Routes.mainView, page: MainView),
   ];
   @override
   Map<Type, StackedRouteFactory> get pagesMap => _pagesMap;
@@ -50,6 +54,12 @@ class StackedRouter extends RouterBase {
     HomeView: (data) {
       return MaterialPageRoute<dynamic>(
         builder: (context) => const HomeView(),
+        settings: data,
+      );
+    },
+    MainView: (data) {
+      return MaterialPageRoute<dynamic>(
+        builder: (context) => const MainView(),
         settings: data,
       );
     },

--- a/packages/testsweets/example/lib/ui/login/login_viewmodel.dart
+++ b/packages/testsweets/example/lib/ui/login/login_viewmodel.dart
@@ -5,8 +5,9 @@ import 'package:stacked_services/stacked_services.dart';
 
 class LoginViewModel extends BaseViewModel {
   final _navigationService = locator<NavigationService>();
+  
   void navigateToOtherView() {
-    _navigationService.navigateTo(Routes.homeView);
+    _navigationService.navigateTo(Routes.mainView);
 
   }
 }

--- a/packages/testsweets/example/lib/ui/main/main_view.dart
+++ b/packages/testsweets/example/lib/ui/main/main_view.dart
@@ -1,0 +1,46 @@
+import 'package:example/ui/main/main_viewmodel.dart';
+import 'package:example/ui/post/post_view.dart';
+import 'package:example/ui/todo/todo_view.dart';
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+
+class MainView extends StatelessWidget {
+  const MainView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder<MainViewModel>.reactive(
+      builder: (context, model, child) => Scaffold(
+        body: getViewForIndex(model.currentIndex),
+        bottomNavigationBar: BottomNavigationBar(
+          type: BottomNavigationBarType.fixed,
+          backgroundColor: Colors.white,
+          currentIndex: model.currentIndex,
+          onTap: model.setIndex,
+          items: [
+            BottomNavigationBarItem(
+              label: 'post',
+              icon: Icon(Icons.post_add),
+            ),
+            BottomNavigationBarItem(
+              label: 'Todo',
+              icon: Icon(Icons.list),
+            ),
+          ],
+        ),
+      ),
+      viewModelBuilder: () => MainViewModel(),
+    );
+  }
+
+  Widget getViewForIndex(int index) {
+    switch (index) {
+      case 0:
+        return PostView();
+      case 1:
+        return TodoView();
+      default:
+        return PostView();
+    }
+  }
+}

--- a/packages/testsweets/example/lib/ui/main/main_view.dart
+++ b/packages/testsweets/example/lib/ui/main/main_view.dart
@@ -1,14 +1,18 @@
+import 'package:example/app/app.router.dart';
 import 'package:example/ui/main/main_viewmodel.dart';
 import 'package:example/ui/post/post_view.dart';
 import 'package:example/ui/todo/todo_view.dart';
 import 'package:flutter/material.dart';
 import 'package:stacked/stacked.dart';
+import 'package:testsweets/testsweets.dart';
 
 class MainView extends StatelessWidget {
   const MainView({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final navigatorObserver = TestSweetsNavigatorObserver();
+
     return ViewModelBuilder<MainViewModel>.reactive(
       builder: (context, model, child) => Scaffold(
         body: getViewForIndex(model.currentIndex),
@@ -16,7 +20,13 @@ class MainView extends StatelessWidget {
           type: BottomNavigationBarType.fixed,
           backgroundColor: Colors.white,
           currentIndex: model.currentIndex,
-          onTap: model.setIndex,
+          onTap: (index) {
+            model.setIndex(index);
+            navigatorObserver.setBottomNavIndex(
+              btmNavBarName: Routes.mainView,
+              index: index,
+            );
+          },
           items: [
             BottomNavigationBarItem(
               label: 'post',

--- a/packages/testsweets/example/lib/ui/main/main_view.dart
+++ b/packages/testsweets/example/lib/ui/main/main_view.dart
@@ -11,8 +11,6 @@ class MainView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final navigatorObserver = TestSweetsNavigatorObserver();
-
     return ViewModelBuilder<MainViewModel>.reactive(
       builder: (context, model, child) => Scaffold(
         body: getViewForIndex(model.currentIndex),
@@ -22,7 +20,7 @@ class MainView extends StatelessWidget {
           currentIndex: model.currentIndex,
           onTap: (index) {
             model.setIndex(index);
-            navigatorObserver.setBottomNavIndex(
+            TestSweetsNavigatorObserver.instance.setBottomNavIndex(
               btmNavBarName: Routes.mainView,
               index: index,
             );

--- a/packages/testsweets/example/lib/ui/main/main_viewmodel.dart
+++ b/packages/testsweets/example/lib/ui/main/main_viewmodel.dart
@@ -1,0 +1,3 @@
+import 'package:stacked/stacked.dart';
+
+class MainViewModel extends IndexTrackingViewModel {}

--- a/packages/testsweets/example/lib/ui/post/post_view.dart
+++ b/packages/testsweets/example/lib/ui/post/post_view.dart
@@ -1,0 +1,35 @@
+import 'package:example/ui/post/post_viewmodel.dart';
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+
+class PostView extends StatelessWidget {
+  const PostView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder<PostViewModel>.reactive(
+      disposeViewModel: false,
+      builder: (context, model, child) => Scaffold(
+        backgroundColor: Colors.greenAccent,
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text(model.post),
+              SizedBox(height: 40),
+              SizedBox(
+                height: 50,
+                width: 200,
+                child: ElevatedButton(
+                  onPressed: model.getPost,
+                  child: Text('Get New Post'),
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+      viewModelBuilder: () => PostViewModel(),
+    );
+  }
+}

--- a/packages/testsweets/example/lib/ui/post/post_viewmodel.dart
+++ b/packages/testsweets/example/lib/ui/post/post_viewmodel.dart
@@ -1,0 +1,20 @@
+import 'dart:math';
+
+import 'package:stacked/stacked.dart';
+
+class PostViewModel extends BaseViewModel {
+  String _post = 'Random Text Generator';
+  String get post => _post;
+
+  void getPost() {
+    _post = _getRandomString(10);
+    notifyListeners();
+  }
+
+  final _chars =
+      'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
+  Random _rnd = Random();
+
+  String _getRandomString(int length) => String.fromCharCodes(Iterable.generate(
+      length, (_) => _chars.codeUnitAt(_rnd.nextInt(_chars.length))));
+}

--- a/packages/testsweets/example/lib/ui/todo/todo_view.dart
+++ b/packages/testsweets/example/lib/ui/todo/todo_view.dart
@@ -1,0 +1,34 @@
+import 'package:example/ui/todo/todo_viewmodel.dart';
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+
+class TodoView extends StatelessWidget {
+  const TodoView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder<TodoViewModel>.reactive(
+      builder: (context, model, child) => Scaffold(
+        backgroundColor: Colors.redAccent,
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text(model.todo),
+              SizedBox(height: 40),
+              SizedBox(
+                height: 50,
+                width: 200,
+                child: ElevatedButton(
+                  onPressed: model.postTodo,
+                  child: Text('Add New Todo'),
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+      viewModelBuilder: () => TodoViewModel(),
+    );
+  }
+}

--- a/packages/testsweets/example/lib/ui/todo/todo_viewmodel.dart
+++ b/packages/testsweets/example/lib/ui/todo/todo_viewmodel.dart
@@ -1,0 +1,21 @@
+import 'dart:math';
+
+import 'package:stacked/stacked.dart';
+
+class TodoViewModel extends BaseViewModel {
+  
+  String _todo = 'Click to post a new Todo';
+  String get todo => _todo;
+
+  void postTodo() {
+    _todo = _getRandomTodo(8);
+    notifyListeners();
+  }
+
+  final _chars =
+      'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
+  Random _rnd = Random();
+
+  String _getRandomTodo(int length) => String.fromCharCodes(Iterable.generate(
+      length, (_) => _chars.codeUnitAt(_rnd.nextInt(_chars.length))));
+}

--- a/packages/testsweets/example/pubspec.lock
+++ b/packages/testsweets/example/pubspec.lock
@@ -536,7 +536,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.4"
+    version: "1.4.5"
   testsweets_generator:
     dependency: "direct dev"
     description:

--- a/packages/testsweets/lib/src/services/testsweets_route_tracker.dart
+++ b/packages/testsweets/lib/src/services/testsweets_route_tracker.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:testsweets/src/app/app.logger.dart';
 
 class TestSweetsRouteTracker extends ChangeNotifier {
+  final log = getLogger('TestSweetsRouteTracker');
+
   static TestSweetsRouteTracker? _instance;
   static TestSweetsRouteTracker get instance {
     if (_instance == null) {
@@ -13,8 +17,10 @@ class TestSweetsRouteTracker extends ChangeNotifier {
   String get currentRoute => _currentRoute;
 
   void setCurrentRoute(String route) {
-    print('setCurrentRoute | route$route');
+    log.i('setCurrentRoute | route: $route');
     _currentRoute = route;
-    notifyListeners();
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
+      notifyListeners();
+    });
   }
 }

--- a/packages/testsweets/lib/src/services/widget_capture_service.dart
+++ b/packages/testsweets/lib/src/services/widget_capture_service.dart
@@ -44,7 +44,7 @@ class WidgetCaptureService {
     }
   }
 
-  void addWidgetDescriptionToMap(WidgetDescription description) {
+  void addWidgetDescriptionToMap({required WidgetDescription description}) {
     if (widgetDescriptionMap.containsKey(description.originalViewName)) {
       widgetDescriptionMap[description.originalViewName]?.add(description);
     } else {

--- a/packages/testsweets/lib/src/ui/testsweets_navigator_observer.dart
+++ b/packages/testsweets/lib/src/ui/testsweets_navigator_observer.dart
@@ -5,6 +5,17 @@ import 'package:testsweets/src/services/testsweets_route_tracker.dart';
 class TestSweetsNavigatorObserver extends NavigatorObserver {
   final routeTracker = locator<TestSweetsRouteTracker>();
 
+  static final TestSweetsNavigatorObserver _instance =
+      TestSweetsNavigatorObserver._internal();
+
+  factory TestSweetsNavigatorObserver() {
+    return _instance;
+  }
+
+  TestSweetsNavigatorObserver._internal();
+
+  static TestSweetsNavigatorObserver get instance => _instance;
+
   @override
   void didPop(Route route, Route? previousRoute) {
     routeTracker.setCurrentRoute(_getRouteName(previousRoute));

--- a/packages/testsweets/lib/src/ui/testsweets_navigator_observer.dart
+++ b/packages/testsweets/lib/src/ui/testsweets_navigator_observer.dart
@@ -29,6 +29,10 @@ class TestSweetsNavigatorObserver extends NavigatorObserver {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
   }
 
+  void setBottomNavIndex({required int index, required String btmNavBarName}) {
+    routeTracker.setCurrentRoute(btmNavBarName + index.toString());
+  }
+
   String _getRouteName(Route? route) {
     return route?.settings.name ?? 'NoView';
   }

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
@@ -234,6 +234,7 @@ class WidgetCaptureViewModel extends FormViewModel {
   void editWidgetDescription() {
     _isEditMode = true;
     _widgetDescription = _activeWidgetDescription;
+    _onChangedValue = _activeWidgetDescription?.name ?? '';
     captureWidgetStatusEnum =
         CaptureWidgetStatusEnum.captureModeWidgetNameInputShow;
     notifyListeners();

--- a/packages/testsweets/lib/testsweets.dart
+++ b/packages/testsweets/lib/testsweets.dart
@@ -5,12 +5,3 @@ export 'src/setup_code.dart';
 export 'src/ui/testsweets_navigator_observer.dart';
 export 'src/ui/testsweets_overlay/testsweets_overlay_view.dart';
 export 'src/ui/widget_capture/widget_capture_view.dart';
-
-// class TestSweets {
-//   /// Creates an tranparent overlay which can be turned on
-//   /// to inspect widgets and their key names
-//   static Widget builder(BuildContext context, Widget child,
-//       {bool enabled = true}) {
-//     return enabled && kDebugMode ? WidgetInspectorView(child: child) : child;
-//   }
-// }

--- a/packages/testsweets/pubspec.yaml
+++ b/packages/testsweets/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   http: ^0.13.3
   auto_size_text: ^3.0.0-nullsafety.0
   yaml: ^3.0.0
-  meta: ^1.4.0
+  meta: ^1.3.0
   get_it: ^7.2.0
   freezed_annotation: ^0.14.3
   json_annotation: ^4.1.0

--- a/packages/testsweets/test/services/widget_capture_service_test.dart
+++ b/packages/testsweets/test/services/widget_capture_service_test.dart
@@ -233,7 +233,8 @@ void main() {
           'When called, should call delete widget description from the CloudFunctionsService',
           () async {
         final description = WidgetDescription(
-          viewName: 'login',
+          originalViewName: '/new_view',
+          viewName: 'newView',
           name: 'email',
           position: WidgetPosition(x: 100, y: 199),
           widgetType: WidgetType.general,
@@ -257,12 +258,14 @@ void main() {
             getWidgetDescriptionForProjectResult: [
               WidgetDescription(
                 viewName: 'login',
+                originalViewName: '/login_view',
                 name: 'loginButton',
                 widgetType: WidgetType.touchable,
                 position: WidgetPosition(x: 0, y: 0),
               ),
               WidgetDescription(
                 viewName: 'signUp',
+                originalViewName: '/login_view',
                 name: 'loginButton',
                 widgetType: WidgetType.touchable,
                 position: WidgetPosition(x: 0, y: 0),
@@ -273,6 +276,7 @@ void main() {
           projectId: 'proj',
           description: WidgetDescription(
             viewName: 'signUp',
+            originalViewName: '/signUp_view',
             name: 'loginButton',
             widgetType: WidgetType.touchable,
             position: WidgetPosition(x: 0, y: 0),
@@ -289,6 +293,7 @@ void main() {
           () async {
         final description = WidgetDescription(
           viewName: 'login',
+          originalViewName: '/login_view',
           name: 'email',
           position: WidgetPosition(x: 100, y: 199),
           widgetType: WidgetType.general,
@@ -312,12 +317,14 @@ void main() {
             getWidgetDescriptionForProjectResult: [
               WidgetDescription(
                 viewName: 'login',
+                originalViewName: '/login_view',
                 name: 'loginButton',
                 widgetType: WidgetType.touchable,
                 position: WidgetPosition(x: 0, y: 0),
               ),
               WidgetDescription(
                 viewName: 'signUp',
+                originalViewName: '/signUp_view',
                 name: 'loginButton',
                 widgetType: WidgetType.touchable,
                 position: WidgetPosition(x: 0, y: 0),
@@ -327,6 +334,8 @@ void main() {
         await service.updateWidgetDescription(
           projectId: 'proj',
           description: WidgetDescription(
+            id: '1234',
+            originalViewName: '/signUp_view',
             viewName: 'signUp',
             name: 'loginBBButton',
             widgetType: WidgetType.touchable,
@@ -334,8 +343,8 @@ void main() {
           ),
         );
 
-        expect(
-            service.widgetDescriptionMap['signUp']!.last.name, 'loginBBButton');
+        expect(service.widgetDescriptionMap['/signUp_view']!.last.name,
+            'loginBBButton');
       });
     });
   });

--- a/packages/testsweets/test/view_models/widget_capture_viewmodel_test.dart
+++ b/packages/testsweets/test/view_models/widget_capture_viewmodel_test.dart
@@ -517,5 +517,49 @@ void main() {
             model.captureWidgetStatusEnum, CaptureWidgetStatusEnum.inspectMode);
       });
     });
+
+    group('editWidgetDescription -', () {
+      test('When called should set isEditMode true', () {
+        final model = WidgetCaptureViewModel(projectId: _projectId);
+        model.editWidgetDescription();
+        expect(model.isEditMode, isTrue);
+      });
+
+      test(
+          'When called should set WidgetDescription to the active WidgetDescription',
+          () {
+        final model = WidgetCaptureViewModel(projectId: _projectId);
+        model.editWidgetDescription();
+
+        expect(model.widgetDescription, model.activeWidgetDescription);
+      });
+
+      test(
+          'When called should set onChangeValue with activeWidgetDescription name',
+          () {
+        final description = WidgetDescription(
+          viewName: '',
+          originalViewName: '',
+          name: 'loginButton',
+          position: WidgetPosition(x: 100, y: 199),
+          widgetType: WidgetType.general,
+        );
+        
+        final model = WidgetCaptureViewModel(projectId: _projectId);
+        model.showWidgetDescription(description);
+        model.editWidgetDescription();
+        
+        expect(model.onChangedValue, model.activeWidgetDescription?.name);
+      });
+
+      test(
+          'When called should set captureWidgetStatusEnum to captureModeWidgetNameInputShow',
+          () {
+        final model = WidgetCaptureViewModel(projectId: _projectId);
+        model.editWidgetDescription();
+        expect(model.captureWidgetStatusEnum,
+            CaptureWidgetStatusEnum.captureModeWidgetNameInputShow);
+      });
+    });
   });
 }

--- a/packages/testsweets/test/view_models/widget_capture_viewmodel_test.dart
+++ b/packages/testsweets/test/view_models/widget_capture_viewmodel_test.dart
@@ -407,6 +407,7 @@ void main() {
           () async {
         final description = WidgetDescription(
           viewName: '',
+          originalViewName: '',
           name: '',
           position: WidgetPosition(x: 100, y: 199),
           widgetType: WidgetType.general,
@@ -462,6 +463,7 @@ void main() {
           () async {
         final description = WidgetDescription(
           viewName: '',
+          originalViewName: '',
           name: 'loginButton',
           position: WidgetPosition(x: 100, y: 199),
           widgetType: WidgetType.general,


### PR DESCRIPTION
The PR fix allow bottom navBar to track onTap changes.

Also adds unit test for additonal changes, which is passing Locally.

![image](https://user-images.githubusercontent.com/46024202/134429798-f3a50b50-e4f6-4dbf-a893-b42828e40fb4.png)


Task remaining:

- [ ] Make `TestSweetsNavigatorObserver` constructor const.