### PR TITLE
Show view's name during capture and inspection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "testsweets",
+            "cwd": "packages\\testsweets",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "example",
+            "cwd": "packages\\testsweets\\example",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "testsweets (profile mode)",
+            "cwd": "packages\\testsweets",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "testsweets_generator",
+            "cwd": "packages\\testsweets_generator",
+            "request": "launch",
+            "type": "dart"
+        }
+    ]
+}

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_view.dart
@@ -9,6 +9,7 @@ import 'package:testsweets/src/ui/shared/busy_indecator.dart';
 import 'package:testsweets/src/ui/shared/cta_button.dart';
 import 'package:testsweets/src/ui/widget_capture/widget_capture_view.form.dart';
 import 'package:testsweets/src/ui/widget_capture/widget_capture_viewmodel.dart';
+import 'package:testsweets/src/ui/widget_capture/widget_capture_widgets/view_name.dart';
 import 'package:testsweets/src/ui/widget_capture/widget_capture_widgets/widget_description_dialog.dart';
 
 import 'widget_capture_widgets/capture_controllers.dart';
@@ -44,6 +45,15 @@ class WidgetCaptureView extends StatelessWidget with $WidgetCaptureView {
                       builder: (context) => Stack(
                             children: [
                               child,
+                              if (model.captureWidgetStatusEnum ==
+                                  CaptureWidgetStatusEnum.inspectMode)
+                                Positioned(
+                                  top: 15,
+                                  right: 10,
+                                  child: ViewName(
+                                    viewName: model.currentView,
+                                  ),
+                                ),
                               if (model
                                   .captureWidgetStatusEnum.isAtInspectModeMode)
                                 InspectControllers(),

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_viewmodel.dart
@@ -24,11 +24,17 @@ class WidgetCaptureViewModel extends FormViewModel {
     syncWithFirestoreWidgetKeys(projectId: projectId);
 
     _testSweetsRouteTracker.addListener(() {
+      _currentView =
+          _testSweetsRouteTracker.currentRoute.convertViewNameToValidFormat;
+      notifyListeners();
       if (_captureWidgetStatusEnum == CaptureWidgetStatusEnum.inspectMode) {
         notifyListeners();
       }
     });
   }
+
+  String _currentView = '';
+  String get currentView => _currentView;
 
   /// the status enum that express the current state of the view
   CaptureWidgetStatusEnum _captureWidgetStatusEnum =

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/black_wrapper_container.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/black_wrapper_container.dart
@@ -11,13 +11,16 @@ class BlackWrapperContainer extends StatelessWidget {
   final Widget child;
   final Widget? footerChild;
   final double? spaceBetweenTopControllersAndChild;
+  final Widget viewName;
+
   const BlackWrapperContainer(
       {Key? key,
       this.switchPositionTap,
       this.closeWidget,
       required this.child,
       this.footerChild,
-      this.spaceBetweenTopControllersAndChild})
+      this.spaceBetweenTopControllersAndChild,
+      this.viewName = const SizedBox.shrink()})
       : super(key: key);
 
   @override
@@ -49,26 +52,32 @@ class BlackWrapperContainer extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       switchPositionTap != null
-                          ? TextButton.icon(
-                              onPressed: switchPositionTap,
-                              style: ButtonStyle(
-                                shape:
-                                    MaterialStateProperty.all<OutlinedBorder>(
+                          ? Row(
+                              children: [
+                                TextButton.icon(
+                                  onPressed: switchPositionTap,
+                                  style: ButtonStyle(
+                                    shape: MaterialStateProperty.all<
+                                            OutlinedBorder>(
                                         RoundedRectangleBorder(
                                             borderRadius: BorderRadius.all(
                                                 crTextFieldCornerRadius()))),
-                                backgroundColor: MaterialStateProperty.all(
-                                    kcSweetsAppBarColor),
-                              ),
-                              icon: Icon(
-                                Icons.swap_vert,
-                                size: 16.w,
-                                color: kcPrimaryWhite,
-                              ),
-                              label: AutoSizeText('Switch Position',
-                                  maxLines: 1,
-                                  style: tsNormal().copyWith(
-                                      color: Colors.white, fontSize: 14.w)),
+                                    backgroundColor: MaterialStateProperty.all(
+                                        kcSweetsAppBarColor),
+                                  ),
+                                  icon: Icon(
+                                    Icons.swap_vert,
+                                    size: 16.w,
+                                    color: kcPrimaryWhite,
+                                  ),
+                                  label: AutoSizeText('Switch Position',
+                                      maxLines: 1,
+                                      style: tsNormal().copyWith(
+                                          color: Colors.white, fontSize: 14.w)),
+                                ),
+                                SizedBox(width: 12.w),
+                                viewName
+                              ],
                             )
                           : const SizedBox(),
                       closeWidget != null

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/capture_layout.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/capture_layout.dart
@@ -50,6 +50,7 @@ class CaptureLayout extends ViewModelWidget<WidgetCaptureViewModel> {
                 onChanged: model.isEditMode ? model.onChangeWidgetName : null,
                 isEditMode: model.isEditMode,
                 errorMessage: model.nameInputErrorMessage,
+                viewName: model.currentView,
                 closeWidget: () {
                   widgetNameController.clear();
                   model.closeWidgetNameInput();

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/view_name.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/view_name.dart
@@ -1,0 +1,27 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:testsweets/src/ui/shared/shared_styles.dart';
+
+class ViewName extends StatelessWidget {
+  final String viewName;
+
+  const ViewName({Key? key, required this.viewName}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () {},
+      style: ButtonStyle(
+        shape: MaterialStateProperty.all<OutlinedBorder>(RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(crTextFieldCornerRadius()))),
+        backgroundColor: MaterialStateProperty.all(Color(0xFFF0276F)),
+      ),
+      child: AutoSizeText(
+        viewName,
+        maxLines: 1,
+        style: tsNormal().copyWith(color: Colors.white, fontSize: 14.w),
+      ),
+    );
+  }
+}

--- a/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_name_input.dart
+++ b/packages/testsweets/lib/src/ui/widget_capture/widget_capture_widgets/widget_name_input.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:testsweets/src/ui/shared/app_colors.dart';
 import 'package:testsweets/src/ui/shared/cta_button.dart';
 import 'package:testsweets/src/ui/shared/shared_styles.dart';
+import 'package:testsweets/src/ui/widget_capture/widget_capture_widgets/view_name.dart';
 
 import 'black_wrapper_container.dart';
 
@@ -18,6 +19,7 @@ class WidgetNameInput extends StatelessWidget {
   final bool isEditMode;
   final String? initialValue;
   final ValueChanged<String>? onChanged;
+  final String viewName;
 
   const WidgetNameInput({
     Key? key,
@@ -28,6 +30,7 @@ class WidgetNameInput extends StatelessWidget {
     required this.closeWidget,
     required this.errorMessage,
     required this.deleteWidget,
+    required this.viewName,
     this.isEditMode = false,
     this.initialValue,
     this.onChanged,
@@ -41,6 +44,7 @@ class WidgetNameInput extends StatelessWidget {
         BlackWrapperContainer(
           switchPositionTap: switchPositionTap,
           closeWidget: closeWidget,
+          viewName: ViewName(viewName: viewName),
           footerChild: FadeInWidget(
               child: Container(
                 width: ScreenUtil().screenWidth,


### PR DESCRIPTION
This PR implement the new way to show the viewName we are in currently.

- [x]  When capturing a widget, We show viewname in container with color `F0276F` the colur of the Touchable representation.
- [x]  When we're in inspect mode. We Show the view name in the top right corner.

# **Preview**

<a href="https://www.loom.com/share/7a56983045f943b9bd340672a326eb37">
    <p>Show View's name during capture and inspection - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/7a56983045f943b9bd340672a326eb37-with-play.gif">
  </a>
  